### PR TITLE
Fix #9: Increased max_tokens to 16384

### DIFF
--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -127,7 +127,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     },
                     {"role": "user", "content": prompt},
                 ],
-                max_tokens=500,
+                max_tokens=16384,
                 n=1,
                 temperature=0.7,
             )


### PR DESCRIPTION
Fix #9: This PR changes the output token limit from 500 tokens to 16384 tokens.

16384 tokens is [the current output limit](https://platform.openai.com/docs/models/gpt-4o-mini) for gpt-4o-mini. At the moment of writing, gpt-4o-mini costs [$0.600 / 1M output tokens](https://openai.com/api/pricing/). This means that a maximum usage of 16384 tokens would cost $0.009 per prompt, which I think is not unreasonable or unresponsible. In the future it would be nice if both the model and the maximum token length are user-configurable values. I do not know how to code that (yet).