### PR TITLE
Fix how the optionsflow handler is invoked

### DIFF
--- a/custom_components/ai_automation_suggester/config_flow.py
+++ b/custom_components/ai_automation_suggester/config_flow.py
@@ -224,7 +224,7 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return AIAutomationOptionsFlowHandler(config_entry)
+        return AIAutomationOptionsFlowHandler()
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
         errors = {}


### PR DESCRIPTION
Fix https://github.com/ITSpecialist111/ai_automation_suggester/issues/56

From https://developers.home-assistant.io/docs/config_entries_options_flow_handler/ you don't need to keep passing the config entry, its just there if you want to read anything.