### PR TITLE
Fix custom open ai

### DIFF
--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -357,13 +357,30 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     self._last_error = f"OpenAI error {resp.status}: {await resp.text()}"
                     _LOGGER.error(self._last_error)
                     return None
-                res = await resp.json()
-                return res["choices"][0]["message"]["content"]
-        except Exception as err:
-            self._last_error = str(err)
-            _LOGGER.error("OpenAI processing error: %s", err)
-            return None
 
+                res = await resp.json()
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "choices" not in res:
+                raise ValueError(f"Response missing 'choices' array: {res}")
+                
+            if not res["choices"] or not isinstance(res["choices"], list):
+                raise ValueError(f"Empty or invalid 'choices' array: {res}")
+                
+            if "message" not in res["choices"][0]:
+                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
+                
+            if "content" not in res["choices"][0]["message"]:
+                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
+                
+            return res["choices"][0]["message"]["content"]
+        
+        except Exception as err:
+            self._last_error = f"OpenAI processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
+            return None
     # ---------------- Anthropic ------------------------------------------------
     async def _anthropic(self, prompt: str) -> str | None:
         try:
@@ -393,12 +410,28 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     self._last_error = f"Anthropic error {resp.status}: {await resp.text()}"
                     _LOGGER.error(self._last_error)
                     return None
+
                 res = await resp.json()
-                return res["content"][0]["text"]
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "content" not in res:
+                raise ValueError(f"Response missing 'content' array: {res}")
+                
+            if not res["content"] or not isinstance(res["content"], list):
+                raise ValueError(f"Empty or invalid 'content' array: {res}")
+                
+            if "text" not in res["content"][0]:
+                raise ValueError(f"First choice missing 'text': {res['content'][0]}")
+                       
+            return res["content"][0]["text"]
+        
         except Exception as err:
-            self._last_error = str(err)
-            _LOGGER.error("Anthropic processing error: %s", err)
+            self._last_error = f"Anthropic processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
             return None
+                
 
     # ---------------- Google ---------------------------------------------------
     async def _google(self, prompt: str) -> str | None:
@@ -428,13 +461,38 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     self._last_error = f"Google error {resp.status}: {await resp.text()}"
                     _LOGGER.error(self._last_error)
                     return None
-                res = await resp.json()
-                return res["candidates"][0]["content"]["parts"][0]["text"]
-        except Exception as err:
-            self._last_error = str(err)
-            _LOGGER.error("Google processing error: %s", err)
-            return None
 
+                res = await resp.json()
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "candidates" not in res:
+                raise ValueError(f"Response missing 'candidates' array: {res}")
+                
+            if not res["candidates"] or not isinstance(res["candidates"], list):
+                raise ValueError(f"Empty or invalid 'candidates' array: {res}")
+                
+            if "content" not in res["candidates"][0]:
+                raise ValueError(f"First choice missing 'content': {res['candidates'][0]}")
+                
+            if "parts" not in res["candidates"][0]["content"]:
+                raise ValueError(f"content missing 'parts': {res['candidates'][0]['message']}")
+            
+            if not res["candidates"][0]["content"]["parts"] or not isinstance(res["candidates"][0]["content"]["parts"], list):
+                raise ValueError(f"Empty or invalid 'parts' array: {res['candidates'][0]['content']}")
+            
+            if "text" not in res["candidates"][0]["content"]["parts"][0]:
+                raise ValueError(f"parts missing 'text': {res['candidates'][0]['content']['parts']}")
+            
+                
+            return res["candidates"][0]["content"]["parts"][0]["text"]
+        
+        except Exception as err:
+            self._last_error = f"Google processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
+            return None
+                
     # ---------------- Groq -----------------------------------------------------
     async def _groq(self, prompt: str) -> str | None:
         try:
@@ -460,11 +518,29 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     self._last_error = f"Groq error {resp.status}: {await resp.text()}"
                     _LOGGER.error(self._last_error)
                     return None
+
                 res = await resp.json()
-                return res["choices"][0]["message"]["content"]
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "choices" not in res:
+                raise ValueError(f"Response missing 'choices' array: {res}")
+                
+            if not res["choices"] or not isinstance(res["choices"], list):
+                raise ValueError(f"Empty or invalid 'choices' array: {res}")
+                
+            if "message" not in res["choices"][0]:
+                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
+                
+            if "content" not in res["choices"][0]["message"]:
+                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
+                
+            return res["choices"][0]["message"]["content"]
+        
         except Exception as err:
-            self._last_error = str(err)
-            _LOGGER.error("Groq processing error: %s", err)
+            self._last_error = f"Groq processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
             return None
 
     # ---------------- LocalAI --------------------------------------------------
@@ -495,11 +571,29 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     self._last_error = f"LocalAI error {resp.status}: {await resp.text()}"
                     _LOGGER.error(self._last_error)
                     return None
+
                 res = await resp.json()
-                return res["choices"][0]["message"]["content"]
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "choices" not in res:
+                raise ValueError(f"Response missing 'choices' array: {res}")
+                
+            if not res["choices"] or not isinstance(res["choices"], list):
+                raise ValueError(f"Empty or invalid 'choices' array: {res}")
+                
+            if "message" not in res["choices"][0]:
+                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
+                
+            if "content" not in res["choices"][0]["message"]:
+                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
+                
+            return res["choices"][0]["message"]["content"]
+        
         except Exception as err:
-            self._last_error = str(err)
-            _LOGGER.error("LocalAI processing error: %s", err)
+            self._last_error = f"LocalAI processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
             return None
 
     # ---------------- Ollama ---------------------------------------------------
@@ -530,13 +624,25 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     self._last_error = f"Ollama error {resp.status}: {await resp.text()}"
                     _LOGGER.error(self._last_error)
                     return None
-                res = await resp.json()
-                return res["message"]["content"]
 
-        except Exception as err:                    # ← this whole block
-            self._last_error = str(err)             #   was missing
-            _LOGGER.error("Ollama processing error: %s", err)
+                res = await resp.json()
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "message" not in res:
+                raise ValueError(f"Response missing 'message' array: {res}")
+                
+            if "content" not in res["message"]:
+                raise ValueError(f"Message missing 'content': {res['message']}")
+                
+            return res["message"]["content"]
+        
+        except Exception as err:
+            self._last_error = f"Ollama processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
             return None
+
     # ---------------- Custom‑endpoint OpenAI -------------------------------
     async def _custom_openai(self, prompt: str) -> str | None:
         try:
@@ -620,10 +726,27 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     _LOGGER.error(self._last_error)
                     return None
                 res = await resp.json()
-                return res["choices"][0]["message"]["content"]
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "choices" not in res:
+                raise ValueError(f"Response missing 'choices' array: {res}")
+                
+            if not res["choices"] or not isinstance(res["choices"], list):
+                raise ValueError(f"Empty or invalid 'choices' array: {res}")
+                
+            if "message" not in res["choices"][0]:
+                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
+                
+            if "content" not in res["choices"][0]["message"]:
+                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
+                
+            return res["choices"][0]["message"]["content"]
+        
         except Exception as err:
-            self._last_error = str(err)
-            _LOGGER.error("Mistral processing error: %s", err)
+            self._last_error = f"Mistral processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
             return None
 
     # ---------------- Perplexity -------------------------------------------
@@ -654,9 +777,27 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     self._last_error = f"Perplexity error {resp.status}: {await resp.text()}"
                     _LOGGER.error(self._last_error)
                     return None
+
                 res = await resp.json()
-                return res["choices"][0]["message"]["content"]
+
+            if not isinstance(res, dict):
+                raise ValueError(f"Unexpected response format: {res}")
+                
+            if "choices" not in res:
+                raise ValueError(f"Response missing 'choices' array: {res}")
+                
+            if not res["choices"] or not isinstance(res["choices"], list):
+                raise ValueError(f"Empty or invalid 'choices' array: {res}")
+                
+            if "message" not in res["choices"][0]:
+                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
+                
+            if "content" not in res["choices"][0]["message"]:
+                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
+                
+            return res["choices"][0]["message"]["content"]
+        
         except Exception as err:
-            self._last_error = str(err)
-            _LOGGER.error("Perplexity processing error: %s", err)
+            self._last_error = f"Perplexity processing error: {str(err)}"
+            _LOGGER.error(self._last_error)
             return None


### PR DESCRIPTION


The "completions" part has been added to the endpoint to standardize it with the rest of the methods.
Fix: #98 

The traces have been changed, previously only an error called 'choices' was shown, now the error message retrieved from the API is shown, for example:
OLD
``` Custom OpenAI processing error: 'choices'```

NEW
```Custom OpenAI processing error: Unexpected response format: {'error': {'message': 'This endpoint\'s maximum context length is 163840 tokens. However, you requested about 186695 tokens (22695 of text input, 164000 in the output). Please reduce the length of either one, or use the "middle-out" transform to compress your prompt automatically.', 'code': 400, 'metadata': {'provider_name': None}}}```
