### PR TITLE
Feat: Expands AI Provider Support & Enhances Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ Leveraging the AI Automation Suggester provides several key benefits:
 
 ## 📦 Features
 
-* **Multi-Provider Support:** Connect to OpenAI, Anthropic, Google, Groq, LocalAI, Ollama, Mistral, or Perplexity.
+* **Multi-Provider Support:** Connect to OpenAI, OpenAI Azure, Anthropic, Google, Groq, LocalAI, Ollama, Mistral, Perplexity, or OpenRouter with full configuration options:
+    * Temperature control for all providers (0.0 - 2.0)
+    * Model selection with provider-specific defaults
+    * Secure API key storage
+    * Custom endpoints for compatible providers
+    * Advanced options like Ollama's think mode control
 * **Customizable Prompts and Filters:** Tailor suggestions using system prompts, domain filters, and entity limits.
 * **Randomized Entity Selection:** Prevent repetitive suggestions and discover new opportunities.
 * **Context-Rich Insights:** Incorporates device and area information for smarter, more relevant ideas.
@@ -157,6 +162,23 @@ You can adjust these settings later via the integration options in Settings → 
 
 ---
 
+## 🛠️ Advanced Configuration
+
+### Global Settings
+
+* **Temperature Control:**
+    * Available for all providers
+    * Range: 0.0 (more focused) to 2.0 (more creative)
+    * Default: 0.7
+    * Configurable in both initial setup and options
+
+* **Token Management:**
+    * Separate input/output token limits
+    * Prevents excessive API usage
+    * Optimizes response length
+
+---
+
 ## ✍️ Usage
 
 ### Automatic Suggestions
@@ -193,6 +215,68 @@ The main sensor (`sensor.ai_automation_suggestions_<provider_name>`) exposes use
     {{ state_attr('sensor.ai_automation_suggestions_<provider_name>', 'yaml_block') }}
     ```
 You can use Markdown cards or other card types to present this information cleanly in your Home Assistant dashboard.
+
+---
+
+## 📊 Monitoring & Diagnostics
+
+The integration provides several sensors for monitoring:
+
+* **AI Automation Suggestions:** (`sensor.ai_automation_suggestions_<provider_name>`)
+    * State: `No Suggestions`, `New Suggestions Available`, `Suggestions Available`
+    * Attributes:
+        * `description`: Human-readable suggestion description
+        * `yaml_block`: Ready-to-use automation YAML
+        * `last_update`: Timestamp of last update
+        * `entities_processed`: List of analyzed entities
+        * `entities_processed_count`: Number of entities analyzed
+
+* **AI Provider Status:** (`sensor.ai_provider_status_<provider_name>`)
+    * State: `connected`, `error`, `disconnected`, `initializing`
+    * Attributes:
+        * `last_error_message`: Details of any errors
+        * `last_attempted_update`: Timestamp of last attempt
+
+* **Max Input/Output Tokens:** (`sensor.max_input_tokens_<provider_name>`, `sensor.max_output_tokens_<provider_name>`)
+    * Shows configured token limits
+    * Helps monitor API usage
+
+* **AI Model:** (`sensor.ai_model_in_use_<provider_name>`)
+    * Shows current model configuration
+    * Useful for multi-instance setups
+
+* **Last Error:** (`sensor.last_error_message_<provider_name>`)
+    * Detailed error tracking
+    * Includes stack traces for unexpected errors
+
+---
+
+## 🔍 Error Handling & Troubleshooting
+
+* **Stack Traces:**
+    * Detailed error logging for unexpected issues
+    * Available in Home Assistant logs
+    * Helpful for debugging API issues
+
+* **Common Error Scenarios:**
+    * API authentication failures
+    * Network connectivity issues
+    * Token limit exceeded
+    * Model availability problems
+    * Response parsing errors
+
+* **Error Monitoring:**
+    * Use the Last Error sensor for real-time error tracking
+    * Check Home Assistant logs for stack traces
+    * Monitor provider status sensor for connection issues
+
+---
+
+## 🔒 Security Notes
+
+* All API keys are stored securely using Home Assistant's secure storage
+* Password fields are properly masked in the UI
+* Local providers (Ollama, LocalAI) can be used for complete data privacy
 
 ---
 

--- a/custom_components/ai_automation_suggester/config_flow.py
+++ b/custom_components/ai_automation_suggester/config_flow.py
@@ -500,6 +500,7 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema = {
             vol.Required(CONF_OPENAI_AZURE_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_OPENAI_AZURE_DEPLOYMENT_ID, default=DEFAULT_MODELS["OpenAI Azure"]): str,
+            vol.Optional(CONF_OPENAI_AZURE_ENDPOINT, default="{your-resource-name}.openai.azure.com"): str,
             vol.Optional(CONF_OPENAI_AZURE_API_VERSION, default="2025-01-01-preview"): str,
             vol.Optional(CONF_OPENAI_AZURE_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
         }
@@ -580,14 +581,15 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[vol.Optional(CONF_LOCALAI_HTTPS, default=self._get_option(CONF_LOCALAI_HTTPS, False))] = bool
             schema[vol.Optional(CONF_LOCALAI_MODEL, default=self._get_option(CONF_LOCALAI_MODEL, DEFAULT_MODELS["LocalAI"]))] = str
             schema[vol.Optional(CONF_LOCALAI_TEMPERATURE, default=self._get_option(CONF_LOCALAI_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
+            schema[vol.Optional(CONF_LOCALAI_IP_ADDRESS, default=self._get_option(CONF_LOCALAI_IP_ADDRESS, "localhost"))] = str
+            schema[vol.Optional(CONF_LOCALAI_PORT, default=self._get_option(CONF_LOCALAI_PORT, 8080))] = int
         elif provider == "Ollama":
             schema[vol.Optional(CONF_OLLAMA_IP_ADDRESS, default=self._get_option(CONF_OLLAMA_IP_ADDRESS, "localhost"))] = str
             schema[vol.Optional(CONF_OLLAMA_PORT, default=self._get_option(CONF_OLLAMA_PORT, 11434))] = int
             schema[vol.Optional(CONF_OLLAMA_HTTPS, default=self._get_option(CONF_OLLAMA_HTTPS, False))] = bool
             schema[vol.Optional(CONF_OLLAMA_MODEL, default=self._get_option(CONF_OLLAMA_MODEL, DEFAULT_MODELS["Ollama"]))] = str
             schema[vol.Optional(CONF_OLLAMA_TEMPERATURE, default=self._get_option(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
-            schema[vol.Optional(CONF_OLLAMA_DISABLE_THINK, default=self._get_option(CONF_OLLAMA_DISABLE_THINK, False))] = bool
-       
+            schema[vol.Optional(CONF_OLLAMA_DISABLE_THINK, default=self._get_option(CONF_OLLAMA_DISABLE_THINK, False))] = bool    
         elif provider == "Custom OpenAI":
             schema[vol.Optional(CONF_CUSTOM_OPENAI_ENDPOINT, default=self._get_option(CONF_CUSTOM_OPENAI_ENDPOINT))] = str
             schema[vol.Optional(CONF_CUSTOM_OPENAI_API_KEY, default=self._get_option(CONF_CUSTOM_OPENAI_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))

--- a/custom_components/ai_automation_suggester/config_flow.py
+++ b/custom_components/ai_automation_suggester/config_flow.py
@@ -578,6 +578,8 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[vol.Optional(CONF_LOCALAI_MODEL, default=self._get_option(CONF_LOCALAI_MODEL, DEFAULT_MODELS["LocalAI"]))] = str
             schema[vol.Optional(CONF_LOCALAI_TEMPERATURE, default=self._get_option(CONF_LOCALAI_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Ollama":
+            schema[vol.Optional(CONF_OLLAMA_IP_ADDRESS, default=self._get_option(CONF_OLLAMA_IP_ADDRESS, "localhost"))] = str
+            schema[vol.Optional(CONF_OLLAMA_PORT, default=self._get_option(CONF_OLLAMA_PORT, 11434))] = int
             schema[vol.Optional(CONF_OLLAMA_HTTPS, default=self._get_option(CONF_OLLAMA_HTTPS, False))] = bool
             schema[vol.Optional(CONF_OLLAMA_MODEL, default=self._get_option(CONF_OLLAMA_MODEL, DEFAULT_MODELS["Ollama"]))] = str
             schema[vol.Optional(CONF_OLLAMA_TEMPERATURE, default=self._get_option(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))

--- a/custom_components/ai_automation_suggester/config_flow.py
+++ b/custom_components/ai_automation_suggester/config_flow.py
@@ -48,6 +48,7 @@ from .const import (  # noqa: E501  (long import list)
     CONF_OLLAMA_HTTPS,
     CONF_OLLAMA_MODEL,
     CONF_OLLAMA_TEMPERATURE,
+    CONF_OLLAMA_DISABLE_THINK,
     CONF_CUSTOM_OPENAI_ENDPOINT,
     CONF_CUSTOM_OPENAI_API_KEY,
     CONF_CUSTOM_OPENAI_MODEL,
@@ -385,6 +386,8 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional(CONF_OLLAMA_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
                 vol.Coerce(float), vol.Range(min=0.0, max=2.0)
             ),
+            vol.Optional(CONF_OLLAMA_DISABLE_THINK, default=False): bool,
+   
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -583,6 +586,8 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[vol.Optional(CONF_OLLAMA_HTTPS, default=self._get_option(CONF_OLLAMA_HTTPS, False))] = bool
             schema[vol.Optional(CONF_OLLAMA_MODEL, default=self._get_option(CONF_OLLAMA_MODEL, DEFAULT_MODELS["Ollama"]))] = str
             schema[vol.Optional(CONF_OLLAMA_TEMPERATURE, default=self._get_option(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
+            schema[vol.Optional(CONF_OLLAMA_DISABLE_THINK, default=self._get_option(CONF_OLLAMA_DISABLE_THINK, False))] = bool
+       
         elif provider == "Custom OpenAI":
             schema[vol.Optional(CONF_CUSTOM_OPENAI_ENDPOINT, default=self._get_option(CONF_CUSTOM_OPENAI_ENDPOINT))] = str
             schema[vol.Optional(CONF_CUSTOM_OPENAI_API_KEY, default=self._get_option(CONF_CUSTOM_OPENAI_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))

--- a/custom_components/ai_automation_suggester/config_flow.py
+++ b/custom_components/ai_automation_suggester/config_flow.py
@@ -27,28 +27,37 @@ from .const import (  # noqa: E501  (long import list)
     # Provider‑specific
     CONF_OPENAI_API_KEY,
     CONF_OPENAI_MODEL,
+    CONF_OPENAI_TEMPERATURE,
     CONF_ANTHROPIC_API_KEY,
     CONF_ANTHROPIC_MODEL,
+    CONF_ANTHROPIC_TEMPERATURE,
     VERSION_ANTHROPIC,
     CONF_GOOGLE_API_KEY,
     CONF_GOOGLE_MODEL,
+    CONF_GOOGLE_TEMPERATURE,
     CONF_GROQ_API_KEY,
     CONF_GROQ_MODEL,
+    CONF_GROQ_TEMPERATURE,
     CONF_LOCALAI_IP_ADDRESS,
     CONF_LOCALAI_PORT,
     CONF_LOCALAI_HTTPS,
     CONF_LOCALAI_MODEL,
+    CONF_LOCALAI_TEMPERATURE,
     CONF_OLLAMA_IP_ADDRESS,
     CONF_OLLAMA_PORT,
     CONF_OLLAMA_HTTPS,
     CONF_OLLAMA_MODEL,
+    CONF_OLLAMA_TEMPERATURE,
     CONF_CUSTOM_OPENAI_ENDPOINT,
     CONF_CUSTOM_OPENAI_API_KEY,
     CONF_CUSTOM_OPENAI_MODEL,
+    CONF_CUSTOM_OPENAI_TEMPERATURE,
     CONF_MISTRAL_API_KEY,
     CONF_MISTRAL_MODEL,
+    CONF_MISTRAL_TEMPERATURE,
     CONF_PERPLEXITY_API_KEY,
     CONF_PERPLEXITY_MODEL,
+    CONF_PERPLEXITY_TEMPERATURE,
     ENDPOINT_PERPLEXITY,
     CONF_OPENROUTER_API_KEY,
     CONF_OPENROUTER_MODEL,
@@ -58,6 +67,7 @@ from .const import (  # noqa: E501  (long import list)
     CONF_OPENAI_AZURE_DEPLOYMENT_ID,
     CONF_OPENAI_AZURE_API_VERSION,
     CONF_OPENAI_AZURE_ENDPOINT,
+    CONF_OPENAI_AZURE_TEMPERATURE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -261,8 +271,9 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_openai(self, user_input=None):
         schema = {
-            vol.Required(CONF_OPENAI_API_KEY): str,
+            vol.Required(CONF_OPENAI_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_OPENAI_MODEL, default=DEFAULT_MODELS["OpenAI"]): str,
+            vol.Optional(CONF_OPENAI_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -282,8 +293,9 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_ANTHROPIC_API_KEY): str,
+            vol.Required(CONF_ANTHROPIC_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_ANTHROPIC_MODEL, default=DEFAULT_MODELS["Anthropic"]): str,
+            vol.Optional(CONF_ANTHROPIC_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -303,8 +315,9 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_GOOGLE_API_KEY): str,
+            vol.Required(CONF_GOOGLE_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_GOOGLE_MODEL, default=DEFAULT_MODELS["Google"]): str,
+            vol.Optional(CONF_GOOGLE_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -319,8 +332,11 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_groq(self, user_input=None):
         schema = {
-            vol.Required(CONF_GROQ_API_KEY): str,
+            vol.Required(CONF_GROQ_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_GROQ_MODEL, default=DEFAULT_MODELS["Groq"]): str,
+            vol.Optional(CONF_GROQ_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
+                vol.Coerce(float), vol.Range(min=0.0, max=2.0)
+            ),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -342,10 +358,13 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_LOCALAI_PORT, default=8080): int,
             vol.Required(CONF_LOCALAI_HTTPS, default=False): bool,
             vol.Optional(CONF_LOCALAI_MODEL, default=DEFAULT_MODELS["LocalAI"]): str,
+            vol.Optional(CONF_LOCALAI_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
+                vol.Coerce(float), vol.Range(min=0.0, max=2.0)
+            ),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
-            "localai",
+            "localai", 
             vol.Schema(schema),
             _v,
             "AI Automation Suggester (LocalAI)",
@@ -363,6 +382,9 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_OLLAMA_PORT, default=11434): int,
             vol.Required(CONF_OLLAMA_HTTPS, default=False): bool,
             vol.Optional(CONF_OLLAMA_MODEL, default=DEFAULT_MODELS["Ollama"]): str,
+            vol.Optional(CONF_OLLAMA_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
+                vol.Coerce(float), vol.Range(min=0.0, max=2.0)
+            ),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -381,8 +403,9 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = {
             vol.Required(CONF_CUSTOM_OPENAI_ENDPOINT): str,
-            vol.Optional(CONF_CUSTOM_OPENAI_API_KEY): str,
+            vol.Optional(CONF_CUSTOM_OPENAI_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_CUSTOM_OPENAI_MODEL, default=DEFAULT_MODELS["Custom OpenAI"]): str,
+            vol.Optional(CONF_CUSTOM_OPENAI_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -402,8 +425,11 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title="AI Automation Suggester (Mistral AI)", data=self.data)
 
         schema = {
-            vol.Required(CONF_MISTRAL_API_KEY): str,
+            vol.Required(CONF_MISTRAL_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_MISTRAL_MODEL, default=DEFAULT_MODELS["Mistral AI"]): str,
+            vol.Optional(CONF_MISTRAL_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
+                vol.Coerce(float), vol.Range(min=0.0, max=2.0)
+            ),
         }
         self._add_token_fields(schema)
         return self.async_show_form(step_id="mistral", data_schema=vol.Schema(schema))
@@ -415,8 +441,11 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_PERPLEXITY_API_KEY): str,
+            vol.Required(CONF_PERPLEXITY_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_PERPLEXITY_MODEL, default=DEFAULT_MODELS["Perplexity AI"]): str,
+            vol.Optional(CONF_PERPLEXITY_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
+                vol.Coerce(float), vol.Range(min=0.0, max=2.0)
+            ),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -437,7 +466,7 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_OPENROUTER_API_KEY): str,
+            vol.Required(CONF_OPENROUTER_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(
                 CONF_OPENROUTER_MODEL, default=DEFAULT_MODELS["OpenRouter"]
             ): str,
@@ -466,9 +495,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return None
 
         schema = {
-            vol.Required(CONF_OPENAI_AZURE_API_KEY): str,
+            vol.Required(CONF_OPENAI_AZURE_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_OPENAI_AZURE_DEPLOYMENT_ID, default=DEFAULT_MODELS["OpenAI Azure"]): str,
             vol.Optional(CONF_OPENAI_AZURE_API_VERSION, default="2025-01-01-preview"): str,
+            vol.Optional(CONF_OPENAI_AZURE_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -530,31 +560,40 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
         if provider == "OpenAI":
             schema[vol.Optional(CONF_OPENAI_API_KEY, default=self._get_option(CONF_OPENAI_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_OPENAI_MODEL, default=self._get_option(CONF_OPENAI_MODEL, DEFAULT_MODELS["OpenAI"]))] = str
+            schema[vol.Optional(CONF_OPENAI_TEMPERATURE, default=self._get_option(CONF_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Anthropic":
             schema[vol.Optional(CONF_ANTHROPIC_API_KEY, default=self._get_option(CONF_ANTHROPIC_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_ANTHROPIC_MODEL, default=self._get_option(CONF_ANTHROPIC_MODEL, DEFAULT_MODELS["Anthropic"]))] = str
+            schema[vol.Optional(CONF_ANTHROPIC_TEMPERATURE, default=self._get_option(CONF_ANTHROPIC_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Google":
             schema[vol.Optional(CONF_GOOGLE_API_KEY, default=self._get_option(CONF_GOOGLE_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_GOOGLE_MODEL, default=self._get_option(CONF_GOOGLE_MODEL, DEFAULT_MODELS["Google"]))] = str
+            schema[vol.Optional(CONF_GOOGLE_TEMPERATURE, default=self._get_option(CONF_GOOGLE_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Groq":
             schema[vol.Optional(CONF_GROQ_API_KEY, default=self._get_option(CONF_GROQ_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_GROQ_MODEL, default=self._get_option(CONF_GROQ_MODEL, DEFAULT_MODELS["Groq"]))] = str
+            schema[vol.Optional(CONF_GROQ_TEMPERATURE, default=self._get_option(CONF_GROQ_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "LocalAI":
             schema[vol.Optional(CONF_LOCALAI_HTTPS, default=self._get_option(CONF_LOCALAI_HTTPS, False))] = bool
             schema[vol.Optional(CONF_LOCALAI_MODEL, default=self._get_option(CONF_LOCALAI_MODEL, DEFAULT_MODELS["LocalAI"]))] = str
+            schema[vol.Optional(CONF_LOCALAI_TEMPERATURE, default=self._get_option(CONF_LOCALAI_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Ollama":
             schema[vol.Optional(CONF_OLLAMA_HTTPS, default=self._get_option(CONF_OLLAMA_HTTPS, False))] = bool
             schema[vol.Optional(CONF_OLLAMA_MODEL, default=self._get_option(CONF_OLLAMA_MODEL, DEFAULT_MODELS["Ollama"]))] = str
+            schema[vol.Optional(CONF_OLLAMA_TEMPERATURE, default=self._get_option(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Custom OpenAI":
             schema[vol.Optional(CONF_CUSTOM_OPENAI_ENDPOINT, default=self._get_option(CONF_CUSTOM_OPENAI_ENDPOINT))] = str
             schema[vol.Optional(CONF_CUSTOM_OPENAI_API_KEY, default=self._get_option(CONF_CUSTOM_OPENAI_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_CUSTOM_OPENAI_MODEL, default=self._get_option(CONF_CUSTOM_OPENAI_MODEL, DEFAULT_MODELS["Custom OpenAI"]))] = str
+            schema[vol.Optional(CONF_CUSTOM_OPENAI_TEMPERATURE, default=self._get_option(CONF_CUSTOM_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Mistral AI":
             schema[vol.Optional(CONF_MISTRAL_API_KEY, default=self._get_option(CONF_MISTRAL_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_MISTRAL_MODEL, default=self._get_option(CONF_MISTRAL_MODEL, DEFAULT_MODELS["Mistral AI"]))] = str
+            schema[vol.Optional(CONF_MISTRAL_TEMPERATURE, default=self._get_option(CONF_MISTRAL_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "Perplexity AI":
             schema[vol.Optional(CONF_PERPLEXITY_API_KEY, default=self._get_option(CONF_PERPLEXITY_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_PERPLEXITY_MODEL, default=self._get_option(CONF_PERPLEXITY_MODEL, DEFAULT_MODELS["Perplexity AI"]))] = str
+            schema[vol.Optional(CONF_PERPLEXITY_TEMPERATURE, default=self._get_option(CONF_PERPLEXITY_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
         elif provider == "OpenRouter":
             schema[vol.Optional(CONF_OPENROUTER_API_KEY, default=self._get_option(CONF_OPENROUTER_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_OPENROUTER_MODEL, default=self._get_option(CONF_OPENROUTER_MODEL, DEFAULT_MODELS["OpenRouter"]))] = str
@@ -565,5 +604,6 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[vol.Optional(CONF_OPENAI_AZURE_ENDPOINT, default=self._get_option(CONF_OPENAI_AZURE_ENDPOINT))] = str
             schema[vol.Optional(CONF_OPENAI_AZURE_DEPLOYMENT_ID, default=self._get_option(CONF_OPENAI_AZURE_DEPLOYMENT_ID, DEFAULT_MODELS["OpenAI Azure"]))] = str
             schema[vol.Optional(CONF_OPENAI_AZURE_API_VERSION, default=self._get_option(CONF_OPENAI_AZURE_API_VERSION, "2025-01-01-preview"))] = str
+            schema[vol.Optional(CONF_OPENAI_AZURE_TEMPERATURE, default=self._get_option(CONF_OPENAI_AZURE_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/custom_components/ai_automation_suggester/const.py
+++ b/custom_components/ai_automation_suggester/const.py
@@ -35,46 +35,55 @@ CONF_PROVIDER = "provider"
 # OpenAI
 CONF_OPENAI_API_KEY = "openai_api_key"
 CONF_OPENAI_MODEL = "openai_model"
+CONF_OPENAI_TEMPERATURE = "openai_temperature"
 
 # OpenAI Azure
 CONF_OPENAI_AZURE_API_KEY = "openai_azure_api_key"
 CONF_OPENAI_AZURE_DEPLOYMENT_ID = "openai_azure_model"
 CONF_OPENAI_AZURE_API_VERSION = "openai_azure_api_version"
 CONF_OPENAI_AZURE_ENDPOINT = "openai_azure_endpoint"
+CONF_OPENAI_AZURE_TEMPERATURE = "openai_azure_temperature"
 
 # Anthropic
 CONF_ANTHROPIC_API_KEY = "anthropic_api_key"
 CONF_ANTHROPIC_MODEL = "anthropic_model"
+CONF_ANTHROPIC_TEMPERATURE = "anthropic_temperature"
 VERSION_ANTHROPIC = "2023-06-01"
 
 # Google
 CONF_GOOGLE_API_KEY = "google_api_key"
 CONF_GOOGLE_MODEL = "google_model"
+CONF_GOOGLE_TEMPERATURE = "google_temperature"
 
 # Groq
 CONF_GROQ_API_KEY = "groq_api_key"
 CONF_GROQ_MODEL = "groq_model"
+CONF_GROQ_TEMPERATURE = "groq_temperature"
 
 # LocalAI
 CONF_LOCALAI_IP_ADDRESS = "localai_ip"
 CONF_LOCALAI_PORT = "localai_port"
 CONF_LOCALAI_HTTPS = "localai_https"
 CONF_LOCALAI_MODEL = "localai_model"
+CONF_LOCALAI_TEMPERATURE = "localai_temperature"
 
 # Ollama
 CONF_OLLAMA_IP_ADDRESS = "ollama_ip"
 CONF_OLLAMA_PORT = "ollama_port"
 CONF_OLLAMA_HTTPS = "ollama_https"
 CONF_OLLAMA_MODEL = "ollama_model"
+CONF_OLLAMA_TEMPERATURE = "ollama_temperature"
 
 # Custom OpenAI
 CONF_CUSTOM_OPENAI_ENDPOINT = "custom_openai_endpoint"
 CONF_CUSTOM_OPENAI_API_KEY = "custom_openai_api_key"
 CONF_CUSTOM_OPENAI_MODEL = "custom_openai_model"
+CONF_CUSTOM_OPENAI_TEMPERATURE = "custom_openai_temperature"
 
 # Mistral AI
 CONF_MISTRAL_API_KEY = "mistral_api_key"
 CONF_MISTRAL_MODEL = "mistral_model"
+CONF_MISTRAL_TEMPERATURE = "mistral_temperature"
 MISTRAL_MODELS = [
     "mistral-tiny",
     "mistral-small",
@@ -85,6 +94,7 @@ MISTRAL_MODELS = [
 # Perplexity AI
 CONF_PERPLEXITY_API_KEY = "perplexity_api_key"
 CONF_PERPLEXITY_MODEL = "perplexity_model"
+CONF_PERPLEXITY_TEMPERATURE = "perplexity_temperature"
 
 # OpenRouter
 CONF_OPENROUTER_API_KEY = "openrouter_api_key"

--- a/custom_components/ai_automation_suggester/const.py
+++ b/custom_components/ai_automation_suggester/const.py
@@ -36,6 +36,12 @@ CONF_PROVIDER = "provider"
 CONF_OPENAI_API_KEY = "openai_api_key"
 CONF_OPENAI_MODEL = "openai_model"
 
+# OpenAI Azure
+CONF_OPENAI_AZURE_API_KEY = "openai_azure_api_key"
+CONF_OPENAI_AZURE_DEPLOYMENT_ID = "openai_azure_model"
+CONF_OPENAI_AZURE_API_VERSION = "openai_azure_api_version"
+CONF_OPENAI_AZURE_ENDPOINT = "openai_azure_endpoint"
+
 # Anthropic
 CONF_ANTHROPIC_API_KEY = "anthropic_api_key"
 CONF_ANTHROPIC_MODEL = "anthropic_model"
@@ -91,6 +97,7 @@ CONF_OPENROUTER_TEMPERATURE = "openrouter_temperature"
 # ─────────────────────────────────────────────────────────────
 DEFAULT_MODELS = {
     "OpenAI": "gpt-4o-mini",
+    "OpenAI Azure": "gpt-4o-mini",
     "Anthropic": "claude-3-7-sonnet-latest",
     "Google": "gemini-2.0-flash",
     "Groq": "llama3-8b-8192",
@@ -121,6 +128,7 @@ PROVIDER_STATUS_INITIALIZING = "initializing"
 # REST endpoints
 # ─────────────────────────────────────────────────────────────
 ENDPOINT_OPENAI = "https://api.openai.com/v1/chat/completions"
+ENDPOINT_OPENAI_AZURE = "https://{endpoint}/openai/deployments/{deployment-id}/chat/completions?api-version={api_version}"
 ENDPOINT_ANTHROPIC = "https://api.anthropic.com/v1/messages"
 ENDPOINT_GOOGLE = "https://generativelanguage.googleapis.com/v1beta2/models/{model}:generateText?key={api_key}"
 ENDPOINT_GROQ = "https://api.groq.com/openai/v1/chat/completions"

--- a/custom_components/ai_automation_suggester/const.py
+++ b/custom_components/ai_automation_suggester/const.py
@@ -73,6 +73,7 @@ CONF_OLLAMA_PORT = "ollama_port"
 CONF_OLLAMA_HTTPS = "ollama_https"
 CONF_OLLAMA_MODEL = "ollama_model"
 CONF_OLLAMA_TEMPERATURE = "ollama_temperature"
+CONF_OLLAMA_DISABLE_THINK = "ollama_disable_think"
 
 # Custom OpenAI
 CONF_CUSTOM_OPENAI_ENDPOINT = "custom_openai_endpoint"

--- a/custom_components/ai_automation_suggester/const.py
+++ b/custom_components/ai_automation_suggester/const.py
@@ -39,7 +39,7 @@ CONF_OPENAI_TEMPERATURE = "openai_temperature"
 
 # OpenAI Azure
 CONF_OPENAI_AZURE_API_KEY = "openai_azure_api_key"
-CONF_OPENAI_AZURE_DEPLOYMENT_ID = "openai_azure_model"
+CONF_OPENAI_AZURE_DEPLOYMENT_ID = "openai_azure_deployment_id"
 CONF_OPENAI_AZURE_API_VERSION = "openai_azure_api_version"
 CONF_OPENAI_AZURE_ENDPOINT = "openai_azure_endpoint"
 CONF_OPENAI_AZURE_TEMPERATURE = "openai_azure_temperature"

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -511,6 +511,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"OpenAI processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in OpenAI API call:")
             return None
 
     # ---------------- OpenAI Azure ---------------------------------------------------
@@ -572,6 +574,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"OpenAI Azure processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in OpenAI Azure API call:")
             return None
 
     # ---------------- Anthropic ------------------------------------------------
@@ -630,6 +634,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"Anthropic processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in Anthropic API call:")
             return None
                 
 
@@ -755,6 +761,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"Groq processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in Groq API call:")
             return None
 
     # ---------------- LocalAI --------------------------------------------------
@@ -811,6 +819,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"LocalAI processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in LocalAI API call:")
             return None
 
     # ---------------- Ollama ---------------------------------------------------
@@ -864,6 +874,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"Ollama processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in Ollama API call:")            
             return None
 
     # ---------------- Custom‑endpoint OpenAI -------------------------------
@@ -925,6 +937,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"Custom OpenAI processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in Custom OpenAI API call:")
             return None
 
     # ---------------- Mistral ----------------------------------------------
@@ -981,6 +995,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"Mistral processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in Mistral API call:")
             return None
 
     # ---------------- Perplexity -------------------------------------------
@@ -1039,6 +1055,8 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"Perplexity processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in Perplexity API call:")
             return None
 
     # ---------------- OpenRouter -------------------------------------------
@@ -1105,4 +1123,6 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         except Exception as err:
             self._last_error = f"OpenRouter processing error: {str(err)}"
             _LOGGER.error(self._last_error)
+            # Log stack trace for unexpected errors
+            _LOGGER.exception("Unexpected error in OpenRouter API call:")
             return None

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -37,34 +37,43 @@ from .const import (  # noqa: E501
     # Provider‑specific keys + endpoints
     CONF_OPENAI_API_KEY,
     CONF_OPENAI_MODEL,
+    CONF_OPENAI_TEMPERATURE,
     ENDPOINT_OPENAI,
     CONF_ANTHROPIC_API_KEY,
     CONF_ANTHROPIC_MODEL,
     VERSION_ANTHROPIC,
     ENDPOINT_ANTHROPIC,
+    CONF_ANTHROPIC_TEMPERATURE,
     CONF_GOOGLE_API_KEY,
     CONF_GOOGLE_MODEL,
+    CONF_GOOGLE_TEMPERATURE,
     CONF_GROQ_API_KEY,
     CONF_GROQ_MODEL,
+    CONF_GROQ_TEMPERATURE,
     ENDPOINT_GROQ,
     CONF_LOCALAI_IP_ADDRESS,
     CONF_LOCALAI_PORT,
     CONF_LOCALAI_HTTPS,
     CONF_LOCALAI_MODEL,
+    CONF_LOCALAI_TEMPERATURE,
     ENDPOINT_LOCALAI,
     CONF_OLLAMA_IP_ADDRESS,
     CONF_OLLAMA_PORT,
     CONF_OLLAMA_HTTPS,
     CONF_OLLAMA_MODEL,
+    CONF_OLLAMA_TEMPERATURE,
     ENDPOINT_OLLAMA,
     CONF_CUSTOM_OPENAI_ENDPOINT,
     CONF_CUSTOM_OPENAI_API_KEY,
     CONF_CUSTOM_OPENAI_MODEL,
+    CONF_CUSTOM_OPENAI_TEMPERATURE,
     CONF_MISTRAL_API_KEY,
     CONF_MISTRAL_MODEL,
+    CONF_MISTRAL_TEMPERATURE,
     ENDPOINT_MISTRAL,
     CONF_PERPLEXITY_API_KEY,
     CONF_PERPLEXITY_MODEL,
+    CONF_PERPLEXITY_TEMPERATURE,
     ENDPOINT_PERPLEXITY,
     CONF_OPENROUTER_API_KEY,
     CONF_OPENROUTER_MODEL,
@@ -75,6 +84,7 @@ from .const import (  # noqa: E501
     CONF_OPENAI_AZURE_DEPLOYMENT_ID,
     CONF_OPENAI_AZURE_API_VERSION,
     CONF_OPENAI_AZURE_ENDPOINT,
+    CONF_OPENAI_AZURE_TEMPERATURE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -450,6 +460,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         try:
             api_key = self._opt(CONF_OPENAI_API_KEY)
             model = self._opt(CONF_OPENAI_MODEL, DEFAULT_MODELS["OpenAI"])
+            temperature = self._opt(CONF_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)
             in_budget, out_budget = self._budgets()
             if not api_key:
                 raise ValueError("OpenAI API key not configured")
@@ -461,7 +472,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": out_budget,
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
             }
             headers = {
                 "Authorization": f"Bearer {api_key}",
@@ -511,6 +522,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             deployment_id = self._opt(CONF_OPENAI_AZURE_DEPLOYMENT_ID)
             api_version = self._opt(CONF_OPENAI_AZURE_API_VERSION, "2025-01-01-preview")
             in_budget, out_budget = self._budgets()
+            temperature = self._opt(CONF_OPENAI_AZURE_TEMPERATURE, DEFAULT_TEMPERATURE)
 
             if not endpoint_base or not deployment_id or not api_version or not api_key:
                 raise ValueError("OpenAI Azure endpoint, deployment, api version or API key not configured")
@@ -527,7 +539,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             body = {
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": out_budget,
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
             }
 
             async with self.session.post(endpoint, headers=headers, json=body) as resp:
@@ -568,6 +580,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             api_key = self._opt(CONF_ANTHROPIC_API_KEY)
             model = self._opt(CONF_ANTHROPIC_MODEL, DEFAULT_MODELS["Anthropic"])
             in_budget, out_budget = self._budgets()
+            temperature = self._opt(CONF_ANTHROPIC_TEMPERATURE, DEFAULT_TEMPERATURE)
             if not api_key:
                 raise ValueError("Anthropic API key not configured")
 
@@ -585,7 +598,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     {"role": "user", "content": [{"type": "text", "text": prompt}]}
                 ],
                 "max_tokens": out_budget,
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
             }
 
             async with self.session.post(
@@ -626,6 +639,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             api_key = self._opt(CONF_GOOGLE_API_KEY)
             model = self._opt(CONF_GOOGLE_MODEL, DEFAULT_MODELS["Google"])
             in_budget, out_budget = self._budgets()
+            temperature = self._opt(CONF_GOOGLE_TEMPERATURE, DEFAULT_TEMPERATURE)
             if not api_key:
                 raise ValueError("Google API key not configured")
 
@@ -635,7 +649,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             body = {
                 "contents": [{"parts": [{"text": prompt}]}],
                 "generationConfig": {
-                    "temperature": DEFAULT_TEMPERATURE,
+                    "temperature": temperature,
                     "maxOutputTokens": out_budget,
                     "topK": 40,
                     "topP": 0.95,
@@ -690,6 +704,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         try:
             api_key = self._opt(CONF_GROQ_API_KEY)
             model = self._opt(CONF_GROQ_MODEL, DEFAULT_MODELS["Groq"])
+            temperature = self._opt(CONF_GROQ_TEMPERATURE, DEFAULT_TEMPERATURE)
             in_budget, out_budget = self._budgets()
             if not api_key:
                 raise ValueError("Groq API key not configured")
@@ -703,7 +718,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                     {"role": "user", "content": [{"type": "text", "text": prompt}]}
                 ],
                 "max_tokens": out_budget,
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
             }
             headers = {
                 "Authorization": f"Bearer {api_key}",
@@ -749,6 +764,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             port = self._opt(CONF_LOCALAI_PORT)
             https = self._opt(CONF_LOCALAI_HTTPS, False)
             model = self._opt(CONF_LOCALAI_MODEL, DEFAULT_MODELS["LocalAI"])
+            temperature = self._opt(CONF_LOCALAI_TEMPERATURE, DEFAULT_TEMPERATURE)
             in_budget, out_budget = self._budgets()
             if not ip or not port:
                 raise ValueError("LocalAI not fully configured")
@@ -763,7 +779,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": out_budget,
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
             }
             async with self.session.post(endpoint, json=body) as resp:
                 if resp.status != 200:
@@ -804,6 +820,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             port = self._opt(CONF_OLLAMA_PORT)
             https = self._opt(CONF_OLLAMA_HTTPS, False)
             model = self._opt(CONF_OLLAMA_MODEL, DEFAULT_MODELS["Ollama"])
+            temperature = self._opt(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE)
             in_budget, out_budget = self._budgets()
             if not ip or not port:
                 raise ValueError("Ollama not fully configured")
@@ -819,7 +836,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": False,
                 "options": {
-                    "temperature": DEFAULT_TEMPERATURE,
+                    "temperature": temperature,
                     "num_predict": out_budget,
                 },
             }
@@ -861,6 +878,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
 
             api_key  = self._opt(CONF_CUSTOM_OPENAI_API_KEY)
             model    = self._opt(CONF_CUSTOM_OPENAI_MODEL, DEFAULT_MODELS["Custom OpenAI"])
+            temperature = self._opt(CONF_CUSTOM_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)
             in_budget, out_budget = self._budgets()
 
 
@@ -875,7 +893,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": out_budget,
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
             }
             async with self.session.post(endpoint, headers=headers, json=body) as resp:
                 if resp.status != 200:
@@ -914,6 +932,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         try:
             api_key = self._opt(CONF_MISTRAL_API_KEY)
             model = self._opt(CONF_MISTRAL_MODEL, DEFAULT_MODELS["Mistral AI"])
+            temperature = self._opt(CONF_MISTRAL_TEMPERATURE, DEFAULT_TEMPERATURE)
             in_budget, out_budget = self._budgets()
             if not api_key:
                 raise ValueError("Mistral API key not configured")
@@ -928,7 +947,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             body = {
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
                 "max_tokens": out_budget,
             }
             async with self.session.post(
@@ -969,6 +988,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         try:
             api_key = self._opt(CONF_PERPLEXITY_API_KEY)
             model = self._opt(CONF_PERPLEXITY_MODEL, DEFAULT_MODELS["Perplexity AI"])
+            temperature = self._opt(CONF_PERPLEXITY_TEMPERATURE, DEFAULT_TEMPERATURE)
             in_budget, out_budget = self._budgets()
             if not api_key:
                 raise ValueError("Perplexity API key not configured")
@@ -985,7 +1005,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": out_budget,
-                "temperature": DEFAULT_TEMPERATURE,
+                "temperature": temperature,
             }
             async with self.session.post(
                 ENDPOINT_PERPLEXITY, headers=headers, json=body

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -62,6 +62,7 @@ from .const import (  # noqa: E501
     CONF_OLLAMA_HTTPS,
     CONF_OLLAMA_MODEL,
     CONF_OLLAMA_TEMPERATURE,
+    CONF_OLLAMA_DISABLE_THINK,
     ENDPOINT_OLLAMA,
     CONF_CUSTOM_OPENAI_ENDPOINT,
     CONF_CUSTOM_OPENAI_API_KEY,
@@ -831,6 +832,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             https = self._opt(CONF_OLLAMA_HTTPS, False)
             model = self._opt(CONF_OLLAMA_MODEL, DEFAULT_MODELS["Ollama"])
             temperature = self._opt(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE)
+            disable_think = self._opt(CONF_OLLAMA_DISABLE_THINK, False)
             in_budget, out_budget = self._budgets()
             if not ip or not port:
                 raise ValueError("Ollama not fully configured")
@@ -841,9 +843,14 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             proto = "https" if https else "http"
             endpoint = ENDPOINT_OLLAMA.format(protocol=proto, ip_address=ip, port=port)
 
+            messages = []
+            if disable_think:
+                messages.append({"role": "system", "content": "/no_think"})
+            messages.append({"role": "user", "content": prompt})
+
             body = {
                 "model": model,
-                "messages": [{"role": "user", "content": prompt}],
+                "messages": messages,
                 "stream": False,
                 "options": {
                     "temperature": temperature,

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -238,7 +238,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                 persistent_notification.async_create(
                     self.hass,
                     message=response,
-                    title="AI Automation Suggestions",
+                    title="AI Automation Suggestions (%s)" % self._opt(CONF_PROVIDER, "unknown"),
                     notification_id=f"ai_automation_suggestions_{now.timestamp()}",
                 )
 

--- a/custom_components/ai_automation_suggester/sensor.py
+++ b/custom_components/ai_automation_suggester/sensor.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_MISTRAL_MODEL,
     CONF_PERPLEXITY_MODEL,
     CONF_OPENROUTER_MODEL,
+    CONF_OPENAI_AZURE_DEPLOYMENT_ID,
     DEFAULT_MODELS,
     # Sensor Keys from const.py
     SENSOR_KEY_SUGGESTIONS,
@@ -67,6 +68,7 @@ PROVIDER_TO_MODEL_KEY_MAP: dict[str, str] = {
     "Mistral AI": CONF_MISTRAL_MODEL,
     "Perplexity AI": CONF_PERPLEXITY_MODEL,
     "OpenRouter": CONF_OPENROUTER_MODEL,
+    "OpenAI Azure": CONF_OPENAI_AZURE_DEPLOYMENT_ID,  
 }
 
 SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (


### PR DESCRIPTION
This pull request is bursting at the seams with a delightful assortment of enhancements to the AI Automation Suggester. I've been tinkering in the workshop and am thrilled to present a feature-packed update that broadens AI model support, streamlines configuration, and improves the overall user experience. So, grab your favorite beverage and let's dive into what's new!

***
### What's in this PR?

* **Azure OpenAI, Welcome to the Party!**: I've rolled out the red carpet for Azure OpenAI. You can now harness the power of your own Azure-hosted OpenAI models for automation suggestions. #117
* **A Configuration Screen Makeover**: I've given the configuration screen a facelift! All the necessary fields are now present and accounted for, with improved formatting for a more intuitive setup experience. No more hide-and-seek with your settings. #90 #100
* **Take Control of the Temperature**: A new option to configure the `temperature` for all supported models has been added (seems like a good option for the summer). Whether you prefer your AI's suggestions to be straight-laced and predictable or wildly creative, you now have the knob to turn. #99
* **Houston, We Have a Stack Trace!**: In the unfortunate event of an unhandled error during requests to your AI model, the integration will now generate a stack trace. This will make debugging those pesky issues a whole lot easier.
* **Ollama's "Thinking" Muzzled (Optionally!)**: For Ollama users, I've introduced a new parameter to silence the "thinking" output in the responses. Get straight to the good stuff without the preamble. #119
* **Provider Name in Notifications**: Ever wondered which of your brilliant AI assistants came up with that latest automation idea? Wonder no more! The provider's name will now be proudly displayed in the notification. It's like a little signature on a piece of art.
* **More Time for Gemini to Shine**: I've noticed that the Gemini model, being the overachiever that it is, enjoys taking in vast amounts of data and contemplating deeply before gracing us with its wisdom. To accommodate its profound thought process, I've increased the response timeout. This ensures you get the best, most well-thought-out suggestions without unnecessary interruptions.

I believe these changes will make the AI Automation Suggester an even more powerful and user-friendly tool for everyone.

Azure OpenAI needs feedback @Antexa

Cheers!