### PR TITLE
Add 1.5.0 foundation release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report a problem with AI Automation Suggester
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+    validations:
+      required: true
+  - type: input
+    id: integration_version
+    attributes:
+      label: AI Automation Suggester version
+    validations:
+      required: true
+  - type: input
+    id: provider
+    attributes:
+      label: Provider and model
+      description: "Example: OpenAI gpt-5.5, Anthropic claude-sonnet-4-6, Ollama llama3.1"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      render: text
+  - type: textarea
+    id: service_data
+    attributes:
+      label: Service call data
+      render: yaml

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest an improvement for AI Automation Suggester
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should the integration help you do?
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Provider, model, Home Assistant workflow, or dashboard context that matters.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Provider/model support
+        - Suggestion quality
+        - Home Assistant native AI
+        - Dashboard/card UX
+        - Localization
+        - Documentation
+        - Other

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- 
+
+## Testing
+
+- [ ] `pytest`
+- [ ] HACS validation
+- [ ] hassfest validation
+
+## Home Assistant Notes
+
+- Minimum HA version affected:
+- Providers tested:
+- Model IDs tested:

--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -11,7 +11,7 @@ jobs:
     name: HACS Action
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v4"
       - name: HACS Action
         uses: "hacs/action@main"
         with:

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v4"
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml ruff
+      - name: Lint helper modules
+        run: ruff check custom_components/ai_automation_suggester/model_catalog.py custom_components/ai_automation_suggester/suggestions.py tests
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
       - name: HACS validation
         uses: hacs/action@main
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## 1.5.0 - 2026-05-03
+
+### Added
+
+- Added model capability metadata for current OpenAI, Azure OpenAI, Anthropic, Gemini, Groq, Mistral, Perplexity, OpenRouter, and local/OpenAI-compatible models.
+- Added OpenAI Responses API routing for GPT-5-style reasoning models and safer token parameter selection for newer OpenAI-compatible models.
+- Added structured suggestion parsing with JSON-first parsing, fenced YAML fallback, YAML validation warnings, and truncation warnings.
+- Added persistent suggestion history with review statuses and HTTP API endpoints for dashboard cards.
+- Added services to clear suggestion history and update suggestion status.
+- Added persistent custom prompt, exclusion filters, history retention, and request timeout options.
+- Added pytest coverage for model catalog and suggestion parsing helpers.
+- Added release notes, issue templates, PR template, and refreshed CI scaffolding.
+
+### Changed
+
+- Updated provider defaults away from stale model IDs, including Gemini 2.0 Flash, legacy Groq Llama 3 IDs, and legacy Mistral aliases.
+- Bumped the integration version to `1.5.0`.
+- Reworked the bundled Lovelace card to use the new stored suggestion API.
+
+### Fixed
+
+- Fixed config entry migration to update the config entry version through Home Assistant's update API.
+- Fixed service-triggered generation so concurrent calls no longer mutate shared coordinator settings without isolation.
+
+## 1.4.2 and earlier
+
+- Earlier releases focused on the initial provider integrations, token budget options, diagnostics sensors, and manual suggestion generation service.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The integration follows a simple, effective process:
 |------|---------------|---------|
 | **1&nbsp;· Snapshot** | Collects data about your home. | On manual trigger or schedule, the integration gathers information on your entities (including attributes), devices, areas, **and** existing automations. You can control the scope using filters and limits. |
 | **2&nbsp;· Prompt Building** | Structures the data for the AI. | This snapshot is embedded into a detailed system prompt describing your specific Home Assistant setup. You can enhance this with a *custom prompt* to steer suggestions towards specific goals (e.g., "focus on presence lighting"). |
-| **3&nbsp;· Provider Call** | Sends the prompt to the AI. | The crafted prompt is sent to your configured AI provider (OpenAI, Anthropic, Google, Groq, LocalAI, Ollama, Mistral, Perplexity). |
-| **4&nbsp;· Parsing** | Processes the AI's response. | The raw response from the AI is parsed to extract key information: a human-readable `description` of the suggestion, the actual `yaml_block` code, and potentially other details. This information is stored on sensor attributes. |
-| **5&nbsp;· Surface** | Delivers the suggestions. | Suggestions appear as Home Assistant persistent notifications. You can also use sensor attributes to display suggestions on custom dashboards for easy review and implementation. |
+| **3&nbsp;· Provider Call** | Sends the prompt to the AI. | The crafted prompt is sent to your configured AI provider (OpenAI, Azure OpenAI, Anthropic, Google, Groq, LocalAI, Ollama, Mistral, Perplexity, OpenRouter, or another OpenAI-compatible endpoint). |
+| **4&nbsp;· Parsing** | Processes the AI's response. | The integration asks capable providers for structured JSON, falls back to fenced YAML parsing, validates returned YAML, and records warnings for missing or possibly truncated output. |
+| **5&nbsp;· Surface** | Delivers and stores the suggestions. | Suggestions appear as Home Assistant persistent notifications, sensor attributes, and stored history that can be used by the bundled dashboard card or your own cards. |
 
 Randomized entity selection (configurable) helps ensure each analysis run can surface fresh ideas rather than repeating the same suggestions.
 
@@ -102,6 +102,8 @@ Leveraging the AI Automation Suggester provides several key benefits:
     * Custom endpoints for compatible providers
     * Advanced options like Ollama's think mode control
 * **Customizable Prompts and Filters:** Tailor suggestions using system prompts, domain filters, and entity limits.
+* **Persistent Suggestion History:** Retain recent suggestions with provider/model metadata, review status, warnings, and generated YAML.
+* **Review Actions:** Mark stored suggestions as accepted, declined, or dismissed through services or the bundled dashboard card.
 * **Randomized Entity Selection:** Prevent repetitive suggestions and discover new opportunities.
 * **Context-Rich Insights:** Incorporates device and area information for smarter, more relevant ideas.
 * **Persistent Notifications:** Receive suggestions directly in your Home Assistant interface.
@@ -114,7 +116,7 @@ Leveraging the AI Automation Suggester provides several key benefits:
 
 ## 🛠️ Prerequisites
 
-* **Home Assistant:** Version 2023.5 or later.
+* **Home Assistant:** Version 2024.1 or later.
 * **AI Provider Setup:** You will need access to an AI model.
     * For cloud providers (OpenAI, Anthropic, Google, Groq, Mistral, Perplexity), you’ll need API keys.
     * For local models (LocalAI, Ollama), ensure the local servers are running and accessible from Home Assistant.
@@ -131,6 +133,8 @@ Leveraging the AI Automation Suggester provides several key benefits:
 4.  Select the integration and click **Download**.
 5.  **Restart Home Assistant**.
 6.  Go to Settings → Devices & Services → **+ Add Integration** and search for `AI Automation Suggester`.
+
+When a GitHub release is published, HACS can detect the new version and show it as an available update. Update through HACS, then restart Home Assistant so the custom integration is reloaded.
 
 ### Manual Installation
 
@@ -177,6 +181,32 @@ You can adjust these settings later via the integration options in Settings → 
     * Prevents excessive API usage
     * Optimizes response length
 
+* **History and Filtering:**
+    * Persistent custom system prompt
+    * Excluded domains, entities, and areas
+    * Stored suggestion history retention
+    * Provider request timeout for slow local or research models
+
+---
+
+## Supported Providers and Model Notes
+
+Model APIs change quickly, so the integration keeps a compatibility catalog and still allows custom model names. Existing configured model values are preserved on upgrade.
+
+| Provider | New default for new configs | Compatibility notes |
+|----------|-----------------------------|---------------------|
+| OpenAI | `gpt-5.4-mini` | GPT-5-style models use the Responses API, `max_output_tokens`, and reasoning effort. Temperature is not sent to models known to reject it. `gpt-5.5` and `gpt-5.5-pro` are supported when available on your account. |
+| Azure OpenAI | `gpt-5.4-mini` deployment name | Azure uses deployment names. Configure the deployment ID, endpoint, and API version that match your Azure resource. |
+| Anthropic | `claude-sonnet-4-6` | Supports current Claude Sonnet/Opus model IDs such as `claude-sonnet-4-6` and `claude-opus-4-7`. |
+| Google Gemini | `gemini-2.5-flash` | Replaces the stale `gemini-2.0-flash` default. Gemini 3 preview IDs can be entered manually. |
+| Groq | `llama-3.3-70b-versatile` | Replaces the stale `llama3-8b-8192` default. Custom Groq model IDs are still allowed. |
+| Mistral AI | `mistral-small-latest` | Supports current `*-latest` aliases and custom published IDs. |
+| Perplexity AI | `sonar` | Supports Sonar, Sonar Pro, reasoning, and research-style model IDs where your account has access. |
+| OpenRouter | `openai/gpt-5.4-mini` | OpenRouter remains dynamic. Use provider-prefixed IDs from OpenRouter's model catalog. |
+| LocalAI/Ollama/custom OpenAI-compatible | User configured | Custom model names remain valid and are treated conservatively. |
+
+For maximum stability, prefer stable model IDs over preview or `latest` aliases unless you intentionally want fast-moving behavior.
+
 ---
 
 ## ✍️ Usage
@@ -199,8 +229,23 @@ You can trigger the suggestion generation manually using the service call:
 3.  Call the service. You can pass parameters to customize the request:
     * `all_entities` (boolean, default: `false`): Set to `true` to consider all eligible entities, `false` to only consider entities added since the last successful run.
     * `domains` (list of strings, optional): Limit the analysis to entities within specific domains (e.g., `['light', 'sensor']`).
+    * `exclude_domains` (list of strings, optional): Exclude domains even when considering all entities.
+    * `exclude_entities` (list of entity IDs, optional): Exclude specific entities from analysis.
+    * `exclude_areas` (list of area IDs/names, optional): Exclude areas from analysis.
     * `entity_limit` (integer, optional): Set a maximum number of entities the AI should consider in this run. Useful for controlling prompt length and cost.
     * `custom_prompt` (string, optional): Add a specific instruction for this particular run (e.g., "Suggest security automations for doors and windows.").
+    * `automation_read_yaml` (boolean, optional): Include YAML from `automations.yaml` for deeper review.
+    * `automation_limit` (integer, optional): Limit how many automations are included.
+
+### Suggestion Review Services
+
+* `ai_automation_suggester.clear_history`: Clears stored suggestion history.
+* `ai_automation_suggester.update_suggestion`: Updates a stored suggestion status. Supported statuses are `new`, `accepted`, `declined`, and `dismissed`.
+
+The bundled dashboard card also uses these stored suggestion APIs:
+
+* `GET /api/ai_automation_suggester/suggestions`
+* `POST /api/ai_automation_suggester/{accept|decline|dismiss}/{suggestion_id}`
 
 ### Dashboard Snippets
 
@@ -230,6 +275,8 @@ The integration provides several sensors for monitoring:
         * `last_update`: Timestamp of last update
         * `entities_processed`: List of analyzed entities
         * `entities_processed_count`: Number of entities analyzed
+        * `suggestion_count`: Number of retained suggestions
+        * `warnings`: Parsing, model, or truncation warnings
 
 * **AI Provider Status:** (`sensor.ai_provider_status_<provider_name>`)
     * State: `connected`, `error`, `disconnected`, `initializing`
@@ -244,6 +291,10 @@ The integration provides several sensors for monitoring:
 * **AI Model:** (`sensor.ai_model_in_use_<provider_name>`)
     * Shows current model configuration
     * Useful for multi-instance setups
+
+* **Suggestion History Count:** (`sensor.suggestion_history_count_<provider_name>`)
+    * Shows how many suggestions are stored in history
+    * Includes latest suggestion ID and review status as attributes
 
 * **Last Error:** (`sensor.last_error_message_<provider_name>`)
     * Detailed error tracking
@@ -274,9 +325,10 @@ The integration provides several sensors for monitoring:
 
 ## 🔒 Security Notes
 
-* All API keys are stored securely using Home Assistant's secure storage
-* Password fields are properly masked in the UI
-* Local providers (Ollama, LocalAI) can be used for complete data privacy
+* API keys are stored in Home Assistant config entries and password fields are masked in the UI.
+* Cloud providers may receive entity IDs, states, attributes, device/area context, automation metadata, and prompt text.
+* Local providers such as Ollama and LocalAI can keep model processing on your own network.
+* Suggestions are review-only. This integration does not automatically create, accept, or modify automations.
 
 ---
 

--- a/custom_components/ai_automation_suggester/__init__.py
+++ b/custom_components/ai_automation_suggester/__init__.py
@@ -1,20 +1,26 @@
 """The AI Automation Suggester integration."""
 import logging
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers.typing import ConfigType
 
+from .api import async_register_http_views
 from .const import (
     DOMAIN,
     PLATFORMS,
     CONF_PROVIDER,
+    SERVICE_CLEAR_HISTORY,
     SERVICE_GENERATE_SUGGESTIONS,
+    SERVICE_UPDATE_SUGGESTION,
     ATTR_PROVIDER_CONFIG,
     ATTR_CUSTOM_PROMPT,
     CONFIG_VERSION
 )
 from .coordinator import AIAutomationCoordinator
+from .store import async_get_suggestion_store
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,34 +33,55 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         new_data = {**config_entry.data}
         new_data.pop('scan_frequency', None)
         new_data.pop('initial_lag_time', None)
-        config_entry.version = CONFIG_VERSION
-        hass.config_entries.async_update_entry(config_entry, data=new_data)
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=CONFIG_VERSION)
         _LOGGER.debug("Migration successful")
         return True
     return True
 
+
+def _listish(value):
+    """Schema helper for service fields that can be a CSV string, list, or object."""
+
+    if value is None:
+        return []
+    if isinstance(value, (str, list, tuple, dict)):
+        return value
+    raise vol.Invalid("expected a list, comma-separated string, or object")
+
+
+GENERATE_SUGGESTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_PROVIDER_CONFIG): str,
+        vol.Optional(ATTR_CUSTOM_PROMPT): str,
+        vol.Optional("all_entities", default=False): bool,
+        vol.Optional("domains", default=[]): _listish,
+        vol.Optional("exclude_domains", default=[]): _listish,
+        vol.Optional("exclude_entities", default=[]): _listish,
+        vol.Optional("exclude_areas", default=[]): _listish,
+        vol.Optional("entity_limit", default=200): vol.All(vol.Coerce(int), vol.Range(min=1, max=2000)),
+        vol.Optional("automation_read_yaml", default=False): bool,
+        vol.Optional("automation_limit", default=100): vol.All(vol.Coerce(int), vol.Range(min=0, max=1000)),
+    }
+)
+
+
+UPDATE_SUGGESTION_SCHEMA = vol.Schema(
+    {
+        vol.Required("suggestion_id"): str,
+        vol.Required("status"): vol.In(["accepted", "declined", "dismissed", "new"]),
+    }
+)
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the AI Automation Suggester component."""
     hass.data.setdefault(DOMAIN, {})
+    async_register_http_views(hass)
 
     async def handle_generate_suggestions(call: ServiceCall) -> None:
         """Handle the generate_suggestions service call."""
-        provider_config = call.data.get(ATTR_PROVIDER_CONFIG)
-        custom_prompt = call.data.get(ATTR_CUSTOM_PROMPT)
-        all_entities = call.data.get("all_entities", False)
-        domains = call.data.get("domains", {})
-        entity_limit = call.data.get("entity_limit", 200)
-        automation_read_yaml = call.data.get("automation_read_yaml", False)
-        automation_limit = call.data.get("automation_limit", 100)
-
-        # Parse domains if provided as a string or dict
-        if isinstance(domains, str):
-            domains = [d.strip() for d in domains.split(',') if d.strip()]
-        elif isinstance(domains, dict):
-            domains = list(domains.keys())
-
         try:
             coordinator = None
+            provider_config = call.data.get(ATTR_PROVIDER_CONFIG)
             if provider_config:
                 coordinator = hass.data[DOMAIN].get(provider_config)
             else:
@@ -67,39 +94,54 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if coordinator is None:
                 raise ServiceValidationError("No AI Automation Suggester provider configured")
 
-            if custom_prompt:
-                original_prompt = coordinator.SYSTEM_PROMPT
-                coordinator.SYSTEM_PROMPT = f"{coordinator.SYSTEM_PROMPT}\n\nAdditional instructions:\n{custom_prompt}"
-            else:
-                original_prompt = None
-
-            coordinator.scan_all = all_entities
-            coordinator.selected_domains = domains
-            coordinator.entity_limit = entity_limit
-            coordinator.automation_read_file = automation_read_yaml
-            coordinator.automation_limit = automation_limit
-
-            try:
-                await coordinator.async_request_refresh()
-            finally:
-                if original_prompt is not None:
-                    coordinator.SYSTEM_PROMPT = original_prompt
-                coordinator.scan_all = False
-                coordinator.selected_domains = []
-                coordinator.entity_limit = 200
-                coordinator.automation_read_file = False
-                coordinator.automation_limit = 100
+            await coordinator.async_generate_suggestions(
+                custom_prompt=call.data.get(ATTR_CUSTOM_PROMPT),
+                all_entities=call.data.get("all_entities", False),
+                domains=call.data.get("domains", []),
+                exclude_domains=call.data.get("exclude_domains", []),
+                exclude_entities=call.data.get("exclude_entities", []),
+                exclude_areas=call.data.get("exclude_areas", []),
+                entity_limit=call.data.get("entity_limit", 200),
+                automation_read_yaml=call.data.get("automation_read_yaml", False),
+                automation_limit=call.data.get("automation_limit", 100),
+            )
 
         except KeyError:
             raise ServiceValidationError("Provider configuration not found")
         except Exception as err:
             raise ServiceValidationError(f"Failed to generate suggestions: {err}")
 
+    async def handle_clear_history(call: ServiceCall) -> None:
+        """Clear stored suggestion history."""
+
+        await async_get_suggestion_store(hass).async_clear()
+
+    async def handle_update_suggestion(call: ServiceCall) -> None:
+        """Update a stored suggestion status."""
+
+        suggestion = await async_get_suggestion_store(hass).async_update_status(
+            call.data["suggestion_id"], call.data["status"]
+        )
+        if suggestion is None:
+            raise ServiceValidationError("Suggestion not found")
+
     # Register the service
     hass.services.async_register(
         DOMAIN,
         SERVICE_GENERATE_SUGGESTIONS,
-        handle_generate_suggestions
+        handle_generate_suggestions,
+        schema=GENERATE_SUGGESTIONS_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_HISTORY,
+        handle_clear_history,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_SUGGESTION,
+        handle_update_suggestion,
+        schema=UPDATE_SUGGESTION_SCHEMA,
     )
 
     return True
@@ -130,9 +172,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.async_create_task(coordinator_request_all_suggestions())
 
         async def coordinator_request_all_suggestions():
-            coordinator.scan_all = True
-            await coordinator.async_request_refresh()
-            coordinator.scan_all = False
+            await coordinator.async_generate_suggestions(all_entities=True)
 
         entry.async_on_unload(hass.bus.async_listen("ai_automation_suggester_update", handle_custom_event))
 

--- a/custom_components/ai_automation_suggester/__init__.py
+++ b/custom_components/ai_automation_suggester/__init__.py
@@ -24,6 +24,8 @@ from .store import async_get_suggestion_store
 
 _LOGGER = logging.getLogger(__name__)
 
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old config entry if necessary."""
     _LOGGER.debug(f"async_migrate_entry {config_entry.version}")

--- a/custom_components/ai_automation_suggester/api.py
+++ b/custom_components/ai_automation_suggester/api.py
@@ -1,0 +1,53 @@
+"""HTTP API endpoints for stored automation suggestions."""
+
+from __future__ import annotations
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+from .store import async_get_suggestion_store
+
+
+class AISuggestionsView(HomeAssistantView):
+    """Return stored suggestions for Lovelace cards and dashboards."""
+
+    url = "/api/ai_automation_suggester/suggestions"
+    name = "api:ai_automation_suggester:suggestions"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        hass: HomeAssistant = request.app["hass"]
+        store = async_get_suggestion_store(hass)
+        return self.json(await store.async_list())
+
+
+class AISuggestionActionView(HomeAssistantView):
+    """Update a suggestion action from the existing custom card."""
+
+    url = "/api/ai_automation_suggester/{action}/{suggestion_id}"
+    name = "api:ai_automation_suggester:suggestion_action"
+    requires_auth = True
+
+    async def post(self, request: web.Request, action: str, suggestion_id: str) -> web.Response:
+        status_map = {
+            "accept": "accepted",
+            "decline": "declined",
+            "dismiss": "dismissed",
+        }
+        if action not in status_map:
+            return self.json({"success": False, "error": "Unsupported action"}, status_code=400)
+
+        hass: HomeAssistant = request.app["hass"]
+        store = async_get_suggestion_store(hass)
+        suggestion = await store.async_update_status(suggestion_id, status_map[action])
+        if suggestion is None:
+            return self.json({"success": False, "error": "Suggestion not found"}, status_code=404)
+        return self.json({"success": True, "suggestion": suggestion})
+
+
+def async_register_http_views(hass: HomeAssistant) -> None:
+    """Register HTTP API views."""
+
+    hass.http.register_view(AISuggestionsView())
+    hass.http.register_view(AISuggestionActionView())

--- a/custom_components/ai_automation_suggester/config_flow.py
+++ b/custom_components/ai_automation_suggester/config_flow.py
@@ -130,7 +130,7 @@ class ProviderValidator:
 class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle integration setup via the UI."""
 
-    VERSION = 1
+    VERSION = CONFIG_VERSION
 
     def __init__(self) -> None:
         self.provider: str | None = None
@@ -143,24 +143,20 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input:
             self.provider = user_input[CONF_PROVIDER]
             self.data.update(user_input)
-
-            if any(ent.data.get(CONF_PROVIDER) == self.provider for ent in self._async_current_entries()):
-                errors["base"] = "already_configured"
-            else:
-                return await {
-                    "OpenAI": self.async_step_openai,
-                    "Anthropic": self.async_step_anthropic,
-                    "Google": self.async_step_google,
-                    "Groq": self.async_step_groq,
-                    "LocalAI": self.async_step_localai,
-                    "Ollama": self.async_step_ollama,
-                    "Custom OpenAI": self.async_step_custom_openai,
-                    "Mistral AI": self.async_step_mistral,
-                    "Perplexity AI": self.async_step_perplexity,
-                    "OpenRouter": self.async_step_openrouter,
-                    "OpenAI Azure": self.async_step_openai_azure,
-                    "Generic OpenAI": self.async_step_generic_openai,
-                }[self.provider]()
+            return await {
+                "OpenAI": self.async_step_openai,
+                "Anthropic": self.async_step_anthropic,
+                "Google": self.async_step_google,
+                "Groq": self.async_step_groq,
+                "LocalAI": self.async_step_localai,
+                "Ollama": self.async_step_ollama,
+                "Custom OpenAI": self.async_step_custom_openai,
+                "Mistral AI": self.async_step_mistral,
+                "Perplexity AI": self.async_step_perplexity,
+                "OpenRouter": self.async_step_openrouter,
+                "OpenAI Azure": self.async_step_openai_azure,
+                "Generic OpenAI": self.async_step_generic_openai,
+            }[self.provider]()
 
         return self.async_show_form(
             step_id="user",
@@ -215,12 +211,22 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     # ───────── provider‑specific steps (OpenAI shown; others similar) ─────────
     def _add_token_fields(self, base: Dict[Any, Any]) -> Dict[Any, Any]:
-        """Append the two token sliders to the schema."""
+        """Append common tuning fields to the schema."""
         base[vol.Optional(CONF_MAX_INPUT_TOKENS, default=DEFAULT_MAX_INPUT_TOKENS)] = vol.All(
             vol.Coerce(int), vol.Range(min=100)
         )
         base[vol.Optional(CONF_MAX_OUTPUT_TOKENS, default=DEFAULT_MAX_OUTPUT_TOKENS)] = vol.All(
             vol.Coerce(int), vol.Range(min=100)
+        )
+        base[vol.Optional(CONF_CUSTOM_SYSTEM_PROMPT, default="")] = str
+        base[vol.Optional(CONF_EXCLUDED_DOMAINS, default="")] = str
+        base[vol.Optional(CONF_EXCLUDED_ENTITIES, default="")] = str
+        base[vol.Optional(CONF_EXCLUDED_AREAS, default="")] = str
+        base[vol.Optional(CONF_HISTORY_RETENTION, default=DEFAULT_HISTORY_RETENTION)] = vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=250)
+        )
+        base[vol.Optional(CONF_REQUEST_TIMEOUT, default=DEFAULT_REQUEST_TIMEOUT)] = vol.All(
+            vol.Coerce(int), vol.Range(min=10, max=1800)
         )
         return base
 
@@ -229,6 +235,7 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_OPENAI_API_KEY): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_OPENAI_MODEL, default=DEFAULT_MODELS["OpenAI"]): str,
             vol.Optional(CONF_OPENAI_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
+            vol.Optional(CONF_OPENAI_REASONING_EFFORT, default=DEFAULT_OPENAI_REASONING_EFFORT): vol.In(["minimal", "low", "medium", "high"]),
         }
         self._add_token_fields(schema)
         return await self._provider_form(
@@ -542,6 +549,12 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             ): vol.All(vol.Coerce(int), vol.Range(min=100)),
             vol.Optional(CONF_MAX_OUTPUT_TOKENS, default=self._get_option(CONF_MAX_OUTPUT_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS)
             ): vol.All(vol.Coerce(int), vol.Range(min=100)),
+            vol.Optional(CONF_CUSTOM_SYSTEM_PROMPT, default=self._get_option(CONF_CUSTOM_SYSTEM_PROMPT, "")): str,
+            vol.Optional(CONF_EXCLUDED_DOMAINS, default=self._get_option(CONF_EXCLUDED_DOMAINS, "")): str,
+            vol.Optional(CONF_EXCLUDED_ENTITIES, default=self._get_option(CONF_EXCLUDED_ENTITIES, "")): str,
+            vol.Optional(CONF_EXCLUDED_AREAS, default=self._get_option(CONF_EXCLUDED_AREAS, "")): str,
+            vol.Optional(CONF_HISTORY_RETENTION, default=self._get_option(CONF_HISTORY_RETENTION, DEFAULT_HISTORY_RETENTION)): vol.All(vol.Coerce(int), vol.Range(min=1, max=250)),
+            vol.Optional(CONF_REQUEST_TIMEOUT, default=self._get_option(CONF_REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT)): vol.All(vol.Coerce(int), vol.Range(min=10, max=1800)),
         }
 
         # provider‑specific editable fields
@@ -549,6 +562,7 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[vol.Optional(CONF_OPENAI_API_KEY, default=self._get_option(CONF_OPENAI_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_OPENAI_MODEL, default=self._get_option(CONF_OPENAI_MODEL, DEFAULT_MODELS["OpenAI"]))] = str
             schema[vol.Optional(CONF_OPENAI_TEMPERATURE, default=self._get_option(CONF_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
+            schema[vol.Optional(CONF_OPENAI_REASONING_EFFORT, default=self._get_option(CONF_OPENAI_REASONING_EFFORT, DEFAULT_OPENAI_REASONING_EFFORT))] = vol.In(["minimal", "low", "medium", "high"])
         elif provider == "Anthropic":
             schema[vol.Optional(CONF_ANTHROPIC_API_KEY, default=self._get_option(CONF_ANTHROPIC_API_KEY))] = TextSelector(TextSelectorConfig(type="password"))
             schema[vol.Optional(CONF_ANTHROPIC_MODEL, default=self._get_option(CONF_ANTHROPIC_MODEL, DEFAULT_MODELS["Anthropic"]))] = str

--- a/custom_components/ai_automation_suggester/const.py
+++ b/custom_components/ai_automation_suggester/const.py
@@ -5,7 +5,7 @@
 # ─────────────────────────────────────────────────────────────
 DOMAIN           = "ai_automation_suggester"
 PLATFORMS        = ["sensor"]
-CONFIG_VERSION   = 2  # config‑entry version (used by async_migrate_entry)
+CONFIG_VERSION   = 3  # config-entry version (used by async_migrate_entry)
 INTEGRATION_NAME = "AI Automation Suggester"
 
 # ─────────────────────────────────────────────────────────────
@@ -23,11 +23,20 @@ DEFAULT_MAX_INPUT_TOKENS = DEFAULT_MAX_TOKENS
 DEFAULT_MAX_OUTPUT_TOKENS = DEFAULT_MAX_TOKENS
 
 DEFAULT_TEMPERATURE = 0.7
+DEFAULT_REQUEST_TIMEOUT = 900
+DEFAULT_HISTORY_RETENTION = 25
+DEFAULT_OPENAI_REASONING_EFFORT = "low"
 
 # ─────────────────────────────────────────────────────────────
 # Provider‑selection key
 # ─────────────────────────────────────────────────────────────
 CONF_PROVIDER = "provider"
+CONF_CUSTOM_SYSTEM_PROMPT = "custom_system_prompt"
+CONF_EXCLUDED_DOMAINS = "excluded_domains"
+CONF_EXCLUDED_ENTITIES = "excluded_entities"
+CONF_EXCLUDED_AREAS = "excluded_areas"
+CONF_HISTORY_RETENTION = "history_retention"
+CONF_REQUEST_TIMEOUT = "request_timeout"
 
 # ─────────────────────────────────────────────────────────────
 # Provider‑specific keys
@@ -36,6 +45,7 @@ CONF_PROVIDER = "provider"
 CONF_OPENAI_API_KEY = "openai_api_key"
 CONF_OPENAI_MODEL = "openai_model"
 CONF_OPENAI_TEMPERATURE = "openai_temperature"
+CONF_OPENAI_REASONING_EFFORT = "openai_reasoning_effort"
 
 # OpenAI Azure
 CONF_OPENAI_AZURE_API_KEY = "openai_azure_api_key"
@@ -86,10 +96,11 @@ CONF_MISTRAL_API_KEY = "mistral_api_key"
 CONF_MISTRAL_MODEL = "mistral_model"
 CONF_MISTRAL_TEMPERATURE = "mistral_temperature"
 MISTRAL_MODELS = [
-    "mistral-tiny",
-    "mistral-small",
-    "mistral-medium",
-    "mistral-large",
+    "mistral-small-latest",
+    "mistral-medium-latest",
+    "mistral-large-latest",
+    "ministral-8b-latest",
+    "codestral-latest",
 ]
 
 # Perplexity AI
@@ -115,18 +126,18 @@ CONF_GENERIC_OPENAI_ENABLE_VALIDATION = "generic_openai_enable_validation"
 # Model defaults per provider
 # ─────────────────────────────────────────────────────────────
 DEFAULT_MODELS = {
-    "OpenAI": "gpt-4o-mini",
-    "OpenAI Azure": "gpt-4o-mini",
-    "Anthropic": "claude-3-7-sonnet-latest",
-    "Google": "gemini-2.0-flash",
-    "Groq": "llama3-8b-8192",
+    "OpenAI": "gpt-5.4-mini",
+    "OpenAI Azure": "gpt-5.4-mini",
+    "Anthropic": "claude-sonnet-4-6",
+    "Google": "gemini-2.5-flash",
+    "Groq": "llama-3.3-70b-versatile",
     "LocalAI": "llama3",
-    "Ollama": "llama2",
-    "Custom OpenAI": "gpt-3.5-turbo",
-    "Mistral AI": "mistral-medium",
+    "Ollama": "llama3.1",
+    "Custom OpenAI": "gpt-4o-mini",
+    "Mistral AI": "mistral-small-latest",
     "Perplexity AI": "sonar",
-    "OpenRouter": "meta-llama/llama-4-maverick:free",
-    "Generic OpenAI": "gpt-3.5-turbo",
+    "OpenRouter": "openai/gpt-5.4-mini",
+    "Generic OpenAI": "gpt-4o-mini",
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -135,6 +146,8 @@ DEFAULT_MODELS = {
 ATTR_PROVIDER_CONFIG = "provider_config"
 ATTR_CUSTOM_PROMPT = "custom_prompt"
 SERVICE_GENERATE_SUGGESTIONS = "generate_suggestions"
+SERVICE_CLEAR_HISTORY = "clear_history"
+SERVICE_UPDATE_SUGGESTION = "update_suggestion"
 
 # ─────────────────────────────────────────────────────────────
 # Provider‑status sensor values
@@ -168,3 +181,4 @@ SENSOR_KEY_INPUT_TOKENS = "input_tokens"
 SENSOR_KEY_OUTPUT_TOKENS = "output_tokens"
 SENSOR_KEY_MODEL = "model"
 SENSOR_KEY_LAST_ERROR = "last_error"
+SENSOR_KEY_HISTORY_COUNT = "history_count"

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -1,13 +1,14 @@
-# custom_components/ai_automation_suggester/coordinator.py
 """Coordinator for AI Automation Suggester."""
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 import logging
 from pathlib import Path
 import random
 import re
+from typing import Any
 
 import aiohttp
 import anyio
@@ -24,13 +25,22 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import *
+from .model_catalog import (
+    chat_token_parameter,
+    compatibility_warnings,
+    json_schema_response_format,
+    model_uses_responses_api,
+    should_send_temperature,
+    supports_json_schema,
+)
+from .store import async_get_suggestion_store
+from .suggestions import (
+    STRUCTURED_OUTPUT_INSTRUCTIONS,
+    format_suggestion_notification,
+    parse_suggestion_response,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-# ─────────────────────────────────────────────────────────────
-# Regex to pull fenced YAML blocks out of the AI response
-# ─────────────────────────────────────────────────────────────
-YAML_RE = re.compile(r"```yaml\s*([\s\S]+?)\s*```", flags=re.IGNORECASE)
 
 SYSTEM_PROMPT = """You are an AI assistant that generates Home Assistant automations
 based on entities, areas and devices, and suggests improvements to existing automations.
@@ -38,7 +48,7 @@ based on entities, areas and devices, and suggests improvements to existing auto
 For each entity:
 1. Understand its function and context.
 2. Consider its current state and attributes.
-3. Suggest context‑aware automations or tweaks, including real entity_ids.
+3. Suggest context-aware automations or tweaks, including real entity_ids.
 
 If asked to focus on a theme (energy saving, presence lighting, etc.), integrate it.
 Also review existing automations and propose improvements.
@@ -46,78 +56,110 @@ If you see a lot of text in a different language, focus on it for a translation 
 """
 
 
-# =============================================================================
-# Coordinator
-# =============================================================================
 class AIAutomationCoordinator(DataUpdateCoordinator):
-    """Builds the prompt, sends it to the selected provider, shares results."""
+    """Build prompts, call the configured provider, and publish suggestions."""
 
-    # --------------------------------------------------------------------- #
-    # Init / lifecycle                                                      #
-    # --------------------------------------------------------------------- #
     def __init__(self, hass: HomeAssistant, entry) -> None:
         self.hass = hass
         self.entry = entry
-
         self.previous_entities: dict[str, dict] = {}
         self.last_update: datetime | None = None
+        self.session = async_get_clientsession(hass)
+        self._generation_lock = asyncio.Lock()
+        self._last_error: str | None = None
+        self._last_response_metadata: dict[str, Any] = {}
 
-        # Tunables modified by the generate_suggestions service
         self.SYSTEM_PROMPT = SYSTEM_PROMPT
         self.scan_all = False
         self.selected_domains: list[str] = []
+        self.excluded_domains: list[str] = self._opt_list(CONF_EXCLUDED_DOMAINS)
+        self.excluded_entities: list[str] = self._opt_list(CONF_EXCLUDED_ENTITIES)
+        self.excluded_areas: list[str] = self._opt_list(CONF_EXCLUDED_AREAS)
         self.entity_limit = 200
-        self.automation_read_file = False  # Default automation reading mode
+        self.automation_read_file = False
         self.automation_limit = 100
 
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=None)
-        self.session = async_get_clientsession(hass)
-
-        self._last_error: str | None = None
 
         self.data: dict = {
             "suggestions": "No suggestions yet",
+            "suggestion": None,
+            "suggestion_history": [],
+            "suggestion_count": 0,
             "description": None,
             "yaml_block": None,
             "last_update": None,
             "entities_processed": [],
             "provider": self._opt(CONF_PROVIDER, "unknown"),
+            "model": self._current_model(),
+            "warnings": [],
             "last_error": None,
+            "response_metadata": {},
         }
 
-        # Registries (populated in async_added_to_hass)
         self.device_registry: dr.DeviceRegistry | None = None
         self.entity_registry: er.EntityRegistry | None = None
         self.area_registry: ar.AreaRegistry | None = None
 
-    # ---------------------------------------------------------------------
-    # Utility – options‑first lookup
-    # ---------------------------------------------------------------------
     def _opt(self, key: str, default=None):
-        """
-        Return config value with this priority:
-          1. entry.options  (saved via Options flow)
-          2. entry.data     (initial setup)
-          3. provided default
-        """
+        """Return entry option, then setup data, then default."""
+
         return self.entry.options.get(key, self.entry.data.get(key, default))
 
-    # ---------------------------------------------------------------------
-    # Helper – token budgets with legacy fallback
-    # ---------------------------------------------------------------------
+    def _opt_list(self, key: str, default: list[str] | None = None) -> list[str]:
+        """Return a normalized list option."""
+
+        value = self._opt(key, default or [])
+        return self._normalize_list(value)
+
+    @staticmethod
+    def _normalize_list(value: Any) -> list[str]:
+        """Normalize strings, dicts, tuples, and lists into a string list."""
+
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, dict):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if isinstance(value, (list, tuple, set)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return [str(value).strip()] if str(value).strip() else []
+
     def _budgets(self) -> tuple[int, int]:
-        """Return (input_budget, output_budget) respecting new + old fields."""
+        """Return input and output token budgets with legacy fallback."""
+
         out_budget = self._opt(
             CONF_MAX_OUTPUT_TOKENS, self._opt(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
         )
         in_budget = self._opt(
             CONF_MAX_INPUT_TOKENS, self._opt(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
         )
-        return in_budget, out_budget
+        return int(in_budget), int(out_budget)
 
-    # ---------------------------------------------------------------------
-    # HA lifecycle hooks
-    # ---------------------------------------------------------------------
+    def _timeout(self) -> aiohttp.ClientTimeout:
+        seconds = int(self._opt(CONF_REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT))
+        return aiohttp.ClientTimeout(total=max(10, seconds))
+
+    def _current_model(self, provider: str | None = None) -> str:
+        provider = provider or self._opt(CONF_PROVIDER, "OpenAI")
+        model_key_map = {
+            "OpenAI": CONF_OPENAI_MODEL,
+            "Anthropic": CONF_ANTHROPIC_MODEL,
+            "Google": CONF_GOOGLE_MODEL,
+            "Groq": CONF_GROQ_MODEL,
+            "LocalAI": CONF_LOCALAI_MODEL,
+            "Ollama": CONF_OLLAMA_MODEL,
+            "Custom OpenAI": CONF_CUSTOM_OPENAI_MODEL,
+            "Mistral AI": CONF_MISTRAL_MODEL,
+            "Perplexity AI": CONF_PERPLEXITY_MODEL,
+            "OpenRouter": CONF_OPENROUTER_MODEL,
+            "OpenAI Azure": CONF_OPENAI_AZURE_DEPLOYMENT_ID,
+            "Generic OpenAI": CONF_GENERIC_OPENAI_MODEL,
+        }
+        model_key = model_key_map.get(provider)
+        return self._opt(model_key, DEFAULT_MODELS.get(provider, "unknown")) if model_key else "unknown"
+
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
         self.device_registry = dr.async_get(self.hass)
@@ -127,77 +169,145 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
     async def async_shutdown(self):
         return
 
-    # ---------------------------------------------------------------------
-    # Main polling routine
-    # ---------------------------------------------------------------------
+    async def async_generate_suggestions(
+        self,
+        *,
+        custom_prompt: str | None = None,
+        all_entities: bool = False,
+        domains: Any = None,
+        exclude_domains: Any = None,
+        exclude_entities: Any = None,
+        exclude_areas: Any = None,
+        entity_limit: int = 200,
+        automation_read_yaml: bool = False,
+        automation_limit: int = 100,
+    ) -> None:
+        """Run one suggestion generation with isolated request settings."""
+
+        async with self._generation_lock:
+            saved = {
+                "SYSTEM_PROMPT": self.SYSTEM_PROMPT,
+                "scan_all": self.scan_all,
+                "selected_domains": self.selected_domains,
+                "excluded_domains": self.excluded_domains,
+                "excluded_entities": self.excluded_entities,
+                "excluded_areas": self.excluded_areas,
+                "entity_limit": self.entity_limit,
+                "automation_read_file": self.automation_read_file,
+                "automation_limit": self.automation_limit,
+            }
+            try:
+                persistent_prompt = str(self._opt(CONF_CUSTOM_SYSTEM_PROMPT, "") or "").strip()
+                prompt_parts = [SYSTEM_PROMPT]
+                if persistent_prompt:
+                    prompt_parts.append(f"Persistent user instructions:\n{persistent_prompt}")
+                if custom_prompt:
+                    prompt_parts.append(f"Request-specific instructions:\n{custom_prompt}")
+                self.SYSTEM_PROMPT = "\n\n".join(prompt_parts)
+                self.scan_all = all_entities
+                self.selected_domains = self._normalize_list(domains)
+                self.excluded_domains = self._normalize_list(exclude_domains) or self._opt_list(CONF_EXCLUDED_DOMAINS)
+                self.excluded_entities = self._normalize_list(exclude_entities) or self._opt_list(CONF_EXCLUDED_ENTITIES)
+                self.excluded_areas = self._normalize_list(exclude_areas) or self._opt_list(CONF_EXCLUDED_AREAS)
+                self.entity_limit = int(entity_limit)
+                self.automation_read_file = bool(automation_read_yaml)
+                self.automation_limit = int(automation_limit)
+                await self.async_request_refresh()
+            finally:
+                self.SYSTEM_PROMPT = saved["SYSTEM_PROMPT"]
+                self.scan_all = saved["scan_all"]
+                self.selected_domains = saved["selected_domains"]
+                self.excluded_domains = saved["excluded_domains"]
+                self.excluded_entities = saved["excluded_entities"]
+                self.excluded_areas = saved["excluded_areas"]
+                self.entity_limit = saved["entity_limit"]
+                self.automation_read_file = saved["automation_read_file"]
+                self.automation_limit = saved["automation_limit"]
+
     async def _async_update_data(self) -> dict:
         try:
             now = datetime.now()
+            provider = self._opt(CONF_PROVIDER, "OpenAI")
+            model = self._current_model(provider)
+            warnings = compatibility_warnings(provider, model)
             self.last_update = now
             self._last_error = None
+            self._last_response_metadata = {}
 
-            # -------------------------------------------------- gather entities
-            current: dict[str, dict] = {}
-            for eid in self.hass.states.async_entity_ids():
-                if (
-                    self.selected_domains
-                    and eid.split(".")[0] not in self.selected_domains
-                ):
-                    continue
-                st = self.hass.states.get(eid)
-                if st:
-                    current[eid] = {
-                        "state": st.state,
-                        "attributes": st.attributes,
-                        "last_changed": st.last_changed,
-                        "last_updated": st.last_updated,
-                        "friendly_name": st.attributes.get("friendly_name", eid),
-                    }
-
-            picked = (
-                current
-                if self.scan_all
-                else {
-                    k: v for k, v in current.items() if k not in self.previous_entities
-                }
-            )
+            current = self._collect_entities()
+            picked = current if self.scan_all else {k: v for k, v in current.items() if k not in self.previous_entities}
             if not picked:
                 self.previous_entities = current
+                history = await async_get_suggestion_store(self.hass).async_list()
+                self.data.update(
+                    {
+                        "suggestion_history": history,
+                        "suggestion_count": len(history),
+                        "provider": provider,
+                        "model": model,
+                        "warnings": warnings,
+                        "last_update": now,
+                    }
+                )
                 return self.data
 
             prompt = await self._build_prompt(picked)
             response = await self._dispatch(prompt)
+            store = async_get_suggestion_store(self.hass)
 
             if response:
-                match = YAML_RE.search(response)
-                yaml_block = match.group(1).strip() if match else None
-                description = YAML_RE.sub("", response).strip() if match else None
+                parsed = parse_suggestion_response(
+                    response,
+                    provider=provider,
+                    model=model,
+                    created_at=now,
+                    entities_processed=list(picked.keys()),
+                    inherited_warnings=warnings,
+                    response_metadata=self._last_response_metadata,
+                )
+                retention = int(self._opt(CONF_HISTORY_RETENTION, DEFAULT_HISTORY_RETENTION))
+                history = await store.async_add_suggestions(parsed, retention=retention)
+                latest = history[0] if history else parsed[0]
 
                 persistent_notification.async_create(
                     self.hass,
-                    message=response,
-                    title="AI Automation Suggestions (%s)" % self._opt(CONF_PROVIDER, "unknown"),
+                    message=format_suggestion_notification(latest),
+                    title=f"AI Automation Suggestions ({provider})",
                     notification_id=f"ai_automation_suggestions_{now.timestamp()}",
                 )
 
                 self.data = {
                     "suggestions": response,
-                    "description": description,
-                    "yaml_block": yaml_block,
+                    "suggestion": latest,
+                    "suggestion_history": history,
+                    "suggestion_count": len(history),
+                    "description": latest.get("description"),
+                    "yaml_block": latest.get("yamlCode"),
                     "last_update": now,
                     "entities_processed": list(picked.keys()),
-                    "provider": self._opt(CONF_PROVIDER, "unknown"),
+                    "provider": provider,
+                    "model": model,
+                    "warnings": latest.get("warnings", warnings),
                     "last_error": None,
+                    "response_metadata": self._last_response_metadata,
                 }
             else:
+                history = await store.async_list()
                 self.data.update(
                     {
                         "suggestions": "No suggestions available",
+                        "suggestion": None,
+                        "suggestion_history": history,
+                        "suggestion_count": len(history),
                         "description": None,
                         "yaml_block": None,
                         "last_update": now,
                         "entities_processed": [],
+                        "provider": provider,
+                        "model": model,
+                        "warnings": warnings,
                         "last_error": self._last_error,
+                        "response_metadata": self._last_response_metadata,
                     }
                 )
 
@@ -206,959 +316,558 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
 
         except Exception as err:  # noqa: BLE001
             self._last_error = str(err)
-            _LOGGER.error("Coordinator fatal error: %s", err)
+            _LOGGER.exception("Coordinator fatal error")
             self.data["last_error"] = self._last_error
             return self.data
 
-    # ---------------------------------------------------------------------
-    # Prompt builder (updated)
-    # ---------------------------------------------------------------------
-    async def _build_prompt(self, entities: dict) -> str:  # noqa: C901
-        """Build the prompt based on entities and automations."""
-        MAX_ATTR = 500
-        MAX_AUTOM = getattr(self, "automation_limit", 100)
+    def _collect_entities(self) -> dict[str, dict]:
+        current: dict[str, dict] = {}
+        selected_domains = set(self.selected_domains)
+        for entity_id in self.hass.states.async_entity_ids():
+            domain = entity_id.split(".", 1)[0]
+            if selected_domains and domain not in selected_domains:
+                continue
+            if self._is_entity_excluded(entity_id):
+                continue
+            state = self.hass.states.get(entity_id)
+            if state:
+                current[entity_id] = {
+                    "state": state.state,
+                    "attributes": state.attributes,
+                    "last_changed": state.last_changed,
+                    "last_updated": state.last_updated,
+                    "friendly_name": state.attributes.get("friendly_name", entity_id),
+                }
+        return current
 
+    def _is_entity_excluded(self, entity_id: str) -> bool:
+        domain = entity_id.split(".", 1)[0]
+        if domain in set(self.excluded_domains):
+            return True
+        if entity_id in set(self.excluded_entities):
+            return True
+        if not self.excluded_areas or not self.entity_registry:
+            return False
+
+        entity_entry = self.entity_registry.async_get(entity_id)
+        device_entry = None
+        if entity_entry and entity_entry.device_id and self.device_registry:
+            device_entry = self.device_registry.async_get(entity_entry.device_id)
+        area_id = entity_entry.area_id if entity_entry and entity_entry.area_id else None
+        if not area_id and device_entry:
+            area_id = device_entry.area_id
+        area_names = {area_id.lower()} if area_id else set()
+        if area_id and self.area_registry:
+            area_entry = self.area_registry.async_get_area(area_id)
+            if area_entry:
+                area_names.add(area_entry.name.lower())
+        excluded = {area.lower() for area in self.excluded_areas}
+        return bool(area_names & excluded)
+
+    async def _build_prompt(self, entities: dict) -> str:
+        max_attr = 500
+        max_autom = self.automation_limit
         ent_sections: list[str] = []
-        for eid, meta in random.sample(
-            list(entities.items()), min(len(entities), self.entity_limit)
-        ):
-            domain = eid.split(".")[0]
+        for entity_id, meta in random.sample(list(entities.items()), min(len(entities), self.entity_limit)):
+            domain = entity_id.split(".", 1)[0]
             attr_str = str(meta["attributes"])
-            if len(attr_str) > MAX_ATTR:
-                attr_str = f"{attr_str[:MAX_ATTR]}...(truncated)"
+            if len(attr_str) > max_attr:
+                attr_str = f"{attr_str[:max_attr]}...(truncated)"
 
-            ent_entry = (
-                self.entity_registry.async_get(eid) if self.entity_registry else None
-            )
-            dev_entry = (
-                self.device_registry.async_get(ent_entry.device_id)
-                if ent_entry and ent_entry.device_id
+            entity_entry = self.entity_registry.async_get(entity_id) if self.entity_registry else None
+            device_entry = (
+                self.device_registry.async_get(entity_entry.device_id)
+                if entity_entry and entity_entry.device_id and self.device_registry
                 else None
             )
-
-            area_id = (
-                ent_entry.area_id
-                if ent_entry and ent_entry.area_id
-                else (dev_entry.area_id if dev_entry else None)
-            )
+            area_id = entity_entry.area_id if entity_entry and entity_entry.area_id else None
+            if not area_id and device_entry:
+                area_id = device_entry.area_id
             area_name = "Unknown Area"
             if area_id and self.area_registry:
-                ar_entry = self.area_registry.async_get_area(area_id)
-                if ar_entry:
-                    area_name = ar_entry.name
+                area_entry = self.area_registry.async_get_area(area_id)
+                if area_entry:
+                    area_name = area_entry.name
 
             block = (
-                f"Entity: {eid}\n"
+                f"Entity: {entity_id}\n"
                 f"Friendly Name: {meta['friendly_name']}\n"
                 f"Domain: {domain}\n"
                 f"State: {meta['state']}\n"
                 f"Attributes: {attr_str}\n"
                 f"Area: {area_name}\n"
             )
-
-            if dev_entry:
+            if device_entry:
                 block += (
                     "Device Info:\n"
-                    f"  Manufacturer: {dev_entry.manufacturer}\n"
-                    f"  Model: {dev_entry.model}\n"
-                    f"  Device Name: {dev_entry.name_by_user or dev_entry.name}\n"
-                    f"  Device ID: {dev_entry.id}\n"
+                    f"  Manufacturer: {device_entry.manufacturer}\n"
+                    f"  Model: {device_entry.model}\n"
+                    f"  Device Name: {device_entry.name_by_user or device_entry.name}\n"
+                    f"  Device ID: {device_entry.id}\n"
                 )
-
-            block += (
-                f"Last Changed: {meta['last_changed']}\n"
-                f"Last Updated: {meta['last_updated']}\n"
-                "---\n"
-            )
+            block += f"Last Changed: {meta['last_changed']}\nLast Updated: {meta['last_updated']}\n---\n"
             ent_sections.append(block)
 
-        # Choose automation reading method
+        autom_sections = self._read_automations_default(max_autom, max_attr)
+        autom_codes: list[str] = []
         if self.automation_read_file:
-            autom_sections = self._read_automations_default(MAX_AUTOM, MAX_ATTR)
-            autom_codes = await self._read_automations_file_method(MAX_AUTOM, MAX_ATTR)
+            autom_codes = await self._read_automations_file_method(max_autom)
 
-            builded_prompt = (
-                f"{self.SYSTEM_PROMPT}\n\n"
-                f"Entities in your Home Assistant (sampled):\n{''.join(ent_sections)}\n"
-                "Existing Automations Overview:\n"
-                f"{''.join(autom_sections) if autom_sections else 'None found.'}\n\n"
-                "Automations YAML Code (for analysis and improvement):\n"
-                f"{''.join(autom_codes) if autom_codes else 'No automations YAML code available.'}\n\n"
-                "Please analyze both the entities and existing automations. "
-                "Propose detailed improvements to existing automations and suggest new ones "
-                "that reference only the entity_ids shown above."
-            )
-        else:
-            autom_sections = self._read_automations_default(MAX_AUTOM, MAX_ATTR)
-
-            builded_prompt = (
-                f"{self.SYSTEM_PROMPT}\n\n"
-                f"Entities in your Home Assistant (sampled):\n{''.join(ent_sections)}\n"
-                "Existing Automations:\n"
-                f"{''.join(autom_sections) if autom_sections else 'None found.'}\n\n"
-                "Please propose detailed automations and improvements that reference only the entity_ids above."
-            )
-
-        return builded_prompt
+        return (
+            f"{self.SYSTEM_PROMPT}\n\n"
+            f"{STRUCTURED_OUTPUT_INSTRUCTIONS}\n\n"
+            f"Entities in your Home Assistant (sampled):\n{''.join(ent_sections)}\n"
+            "Existing Automations Overview:\n"
+            f"{''.join(autom_sections) if autom_sections else 'None found.'}\n\n"
+            "Automations YAML Code (for analysis and improvement):\n"
+            f"{''.join(autom_codes) if autom_codes else 'No automations YAML code included.'}\n\n"
+            "Analyze the entities and existing automations. Propose useful new automations or improvements "
+            "that reference only the entity_ids shown above."
+        )
 
     def _read_automations_default(self, max_autom: int, max_attr: int) -> list[str]:
-        """Default method for reading automations."""
         autom_sections: list[str] = []
-        for aid in self.hass.states.async_entity_ids("automation")[:max_autom]:
-            st = self.hass.states.get(aid)
-            if st:
-                attr = str(st.attributes)
+        for automation_id in self.hass.states.async_entity_ids("automation")[:max_autom]:
+            state = self.hass.states.get(automation_id)
+            if state:
+                attr = str(state.attributes)
                 if len(attr) > max_attr:
                     attr = f"{attr[:max_attr]}...(truncated)"
                 autom_sections.append(
-                    f"Entity: {aid}\n"
-                    f"Friendly Name: {st.attributes.get('friendly_name', aid)}\n"
-                    f"State: {st.state}\n"
+                    f"Entity: {automation_id}\n"
+                    f"Friendly Name: {state.attributes.get('friendly_name', automation_id)}\n"
+                    f"State: {state.state}\n"
                     f"Attributes: {attr}\n"
                     "---\n"
                 )
         return autom_sections
 
-    async def _read_automations_file_method(self, max_autom: int, max_attr: int) -> list[str]:
-        """File method for reading automations."""
+    async def _read_automations_file_method(self, max_autom: int) -> list[str]:
         automations_file = Path(self.hass.config.path()) / "automations.yaml"
         autom_codes: list[str] = []
-
         try:
-            async with await anyio.open_file(
-                automations_file, "r", encoding="utf-8"
-            ) as file:
+            async with await anyio.open_file(automations_file, "r", encoding="utf-8") as file:
                 content = await file.read()
-                automations = yaml.safe_load(content)
-
+            automations = yaml.safe_load(content) or []
+            if not isinstance(automations, list):
+                _LOGGER.warning("automations.yaml did not parse as a list")
+                return autom_codes
             for automation in automations[:max_autom]:
-                aid = automation.get("id", "unknown_id")
-                alias = automation.get("alias", "Unnamed Automation")
-                description = automation.get("description", "")
-                trigger = automation.get("trigger", []) + automation.get("triggers", [])
-                condition = automation.get("condition", []) + automation.get(
-                    "conditions", []
+                if not isinstance(automation, dict):
+                    continue
+                autom_codes.append(
+                    "Automation YAML:\n```yaml\n"
+                    f"{yaml.safe_dump([automation], sort_keys=False)}"
+                    "```\n---\n"
                 )
-                action = automation.get("action", []) + automation.get("actions", [])
-
-                # YAML
-                code_block = (
-                    f"Automation Code for automation.{aid}:\n"
-                    "```yaml\n"
-                    f"- id: '{aid}'\n"
-                    f"  alias: '{alias}'\n"
-                    f"  description: '{description}'\n"
-                    f"  trigger: {trigger}\n"
-                    f"  condition: {condition}\n"
-                    f"  action: {action}\n"
-                    "```\n"
-                    "---\n"
-                )
-                autom_codes.append(code_block)
-
         except FileNotFoundError:
-            _LOGGER.error("The automations.yaml file was not found.")
+            _LOGGER.warning("automations.yaml file was not found")
         except yaml.YAMLError as err:
-            _LOGGER.error("Error parsing automations.yaml: %s", err)
-
+            _LOGGER.warning("Error parsing automations.yaml: %s", err)
         return autom_codes
 
-    # ---------------------------------------------------------------------
-    # Provider dispatcher
-    # ---------------------------------------------------------------------
     async def _dispatch(self, prompt: str) -> str | None:
         provider = self._opt(CONF_PROVIDER, "OpenAI")
-        self._last_error = None
-        try:
-            return await {
-                "OpenAI": self._openai,
-                "Anthropic": self._anthropic,
-                "Google": self._google,
-                "Groq": self._groq,
-                "LocalAI": self._localai,
-                "Ollama": self._ollama,
-                "Custom OpenAI": self._custom_openai,
-                "Mistral AI": self._mistral,
-                "Perplexity AI": self._perplexity,
-                "OpenRouter": self._openrouter,
-                "OpenAI Azure": self._openai_azure,
-                "Generic OpenAI": self._generic_openai,
-            }[provider](prompt)
-        except KeyError:
+        dispatch = {
+            "OpenAI": self._openai,
+            "Anthropic": self._anthropic,
+            "Google": self._google,
+            "Groq": self._groq,
+            "LocalAI": self._localai,
+            "Ollama": self._ollama,
+            "Custom OpenAI": self._custom_openai,
+            "Mistral AI": self._mistral,
+            "Perplexity AI": self._perplexity,
+            "OpenRouter": self._openrouter,
+            "OpenAI Azure": self._openai_azure,
+            "Generic OpenAI": self._generic_openai,
+        }
+        handler = dispatch.get(provider)
+        if handler is None:
             self._last_error = f"Unknown provider '{provider}'"
             _LOGGER.error(self._last_error)
             return None
+        try:
+            return await handler(prompt)
         except Exception as err:  # noqa: BLE001
             self._last_error = str(err)
-            _LOGGER.error("Dispatch error: %s", err)
+            _LOGGER.exception("Dispatch error for %s", provider)
             return None
 
-    # ---------------------------------------------------------------------
-    # Provider implementations (OpenAI shown; the rest follow same pattern)
-    # ---------------------------------------------------------------------
+    def _trim_prompt(self, prompt: str) -> str:
+        in_budget, _ = self._budgets()
+        if len(prompt) // 4 > in_budget:
+            return prompt[: in_budget * 4]
+        return prompt
+
+    async def _post_json(
+        self,
+        endpoint: str,
+        *,
+        headers: dict[str, str] | None = None,
+        body: dict[str, Any],
+        provider_label: str,
+    ) -> dict[str, Any] | None:
+        async with self.session.post(
+            endpoint,
+            headers=headers,
+            json=body,
+            timeout=self._timeout(),
+        ) as response:
+            response_text = await response.text()
+            if response.status != 200:
+                self._last_error = f"{provider_label} error {response.status}: {response_text}"
+                _LOGGER.error(self._last_error)
+                return None
+            try:
+                return await response.json(content_type=None)
+            except Exception as err:  # noqa: BLE001
+                self._last_error = f"{provider_label} returned non-JSON response: {err}: {response_text[:500]}"
+                _LOGGER.error(self._last_error)
+                return None
+
+    def _openai_compatible_body(
+        self,
+        *,
+        provider: str,
+        model: str,
+        prompt: str,
+        temperature: float,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        _, out_budget = self._budgets()
+        body: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            chat_token_parameter(provider, model): out_budget,
+        }
+        if should_send_temperature(provider, model):
+            body["temperature"] = temperature
+        if supports_json_schema(provider, model):
+            body["response_format"] = json_schema_response_format()
+        if extra:
+            body.update(extra)
+        return body
+
+    def _extract_chat_content(self, response: dict[str, Any], provider_label: str) -> str | None:
+        choices = response.get("choices")
+        if not isinstance(choices, list) or not choices:
+            raise ValueError(f"{provider_label} response missing choices array: {response}")
+        choice = choices[0]
+        self._last_response_metadata = {
+            "finish_reason": choice.get("finish_reason"),
+            "native_finish_reason": choice.get("native_finish_reason"),
+            "usage": response.get("usage"),
+        }
+        message = choice.get("message") or {}
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "".join(part.get("text", "") for part in content if isinstance(part, dict))
+        raise ValueError(f"{provider_label} message missing content: {message}")
+
     async def _openai(self, prompt: str) -> str | None:
-        try:
-            api_key = self._opt(CONF_OPENAI_API_KEY)
-            model = self._opt(CONF_OPENAI_MODEL, DEFAULT_MODELS["OpenAI"])
-            temperature = self._opt(CONF_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)
-            in_budget, out_budget = self._budgets()
-            if not api_key:
-                raise ValueError("OpenAI API key not configured")
+        api_key = self._opt(CONF_OPENAI_API_KEY)
+        if not api_key:
+            raise ValueError("OpenAI API key not configured")
+        model = self._current_model("OpenAI")
+        prompt = self._trim_prompt(prompt)
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        if model_uses_responses_api("OpenAI", model):
+            return await self._openai_responses(prompt, model, headers)
+        body = self._openai_compatible_body(
+            provider="OpenAI",
+            model=model,
+            prompt=prompt,
+            temperature=float(self._opt(CONF_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        )
+        response = await self._post_json(ENDPOINT_OPENAI, headers=headers, body=body, provider_label="OpenAI")
+        return self._extract_chat_content(response, "OpenAI") if response else None
 
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            body = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(
-                ENDPOINT_OPENAI, headers=headers, json=body, timeout=timeout
-            ) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"OpenAI error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-                
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-                
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-                
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-                
-            return res["choices"][0]["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"OpenAI processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in OpenAI API call:")
+    async def _openai_responses(self, prompt: str, model: str, headers: dict[str, str]) -> str | None:
+        _, out_budget = self._budgets()
+        body: dict[str, Any] = {
+            "model": model,
+            "input": [{"role": "user", "content": prompt}],
+            "max_output_tokens": out_budget,
+            "reasoning": {
+                "effort": self._opt(CONF_OPENAI_REASONING_EFFORT, DEFAULT_OPENAI_REASONING_EFFORT)
+            },
+            "text": {"format": {"type": "json_schema", **json_schema_response_format()["json_schema"]}},
+        }
+        response = await self._post_json(
+            "https://api.openai.com/v1/responses",
+            headers=headers,
+            body=body,
+            provider_label="OpenAI Responses",
+        )
+        if not response:
             return None
+        self._last_response_metadata = {
+            "status": response.get("status"),
+            "incomplete_details": response.get("incomplete_details"),
+            "usage": response.get("usage"),
+        }
+        if isinstance(response.get("output_text"), str):
+            return response["output_text"]
+        output = response.get("output") or []
+        text_parts: list[str] = []
+        for item in output:
+            for content in item.get("content", []) if isinstance(item, dict) else []:
+                if isinstance(content, dict) and content.get("type") in {"output_text", "text"}:
+                    text_parts.append(str(content.get("text", "")))
+        return "".join(text_parts) if text_parts else None
 
-    # ---------------- OpenAI Azure ---------------------------------------------------
     async def _openai_azure(self, prompt: str) -> str | None:
-        """Send prompt to OpenAI Azure endpoint."""
-        try:
-            endpoint_base = self._opt(CONF_OPENAI_AZURE_ENDPOINT)
-            api_key = self._opt(CONF_OPENAI_AZURE_API_KEY)
-            deployment_id = self._opt(CONF_OPENAI_AZURE_DEPLOYMENT_ID)
-            api_version = self._opt(CONF_OPENAI_AZURE_API_VERSION, "2025-01-01-preview")
-            in_budget, out_budget = self._budgets()
-            temperature = self._opt(CONF_OPENAI_AZURE_TEMPERATURE, DEFAULT_TEMPERATURE)
+        endpoint_base = self._opt(CONF_OPENAI_AZURE_ENDPOINT)
+        api_key = self._opt(CONF_OPENAI_AZURE_API_KEY)
+        deployment_id = self._opt(CONF_OPENAI_AZURE_DEPLOYMENT_ID)
+        api_version = self._opt(CONF_OPENAI_AZURE_API_VERSION, "2025-01-01-preview")
+        if not endpoint_base or not deployment_id or not api_key:
+            raise ValueError("Azure OpenAI endpoint, deployment, or API key not configured")
+        endpoint_base = str(endpoint_base).rstrip("/")
+        if not re.match(r"^https?://", endpoint_base):
+            endpoint_base = f"https://{endpoint_base}"
+        endpoint = f"{endpoint_base}/openai/deployments/{deployment_id}/chat/completions?api-version={api_version}"
+        _, out_budget = self._budgets()
+        model = self._current_model("OpenAI Azure")
+        body: dict[str, Any] = {
+            "messages": [{"role": "user", "content": self._trim_prompt(prompt)}],
+            chat_token_parameter("OpenAI Azure", model): out_budget,
+        }
+        if should_send_temperature("OpenAI Azure", model):
+            body["temperature"] = float(self._opt(CONF_OPENAI_AZURE_TEMPERATURE, DEFAULT_TEMPERATURE))
+        response = await self._post_json(
+            endpoint,
+            headers={"api-key": api_key, "Content-Type": "application/json"},
+            body=body,
+            provider_label="Azure OpenAI",
+        )
+        return self._extract_chat_content(response, "Azure OpenAI") if response else None
 
-            if not endpoint_base or not deployment_id or not api_version or not api_key:
-                raise ValueError("OpenAI Azure endpoint, deployment, api version or API key not configured")
-
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            endpoint = f"https://{endpoint_base}/openai/deployments/{deployment_id}/chat/completions?api-version={api_version}"
-
-            headers = {
-                "api-key": api_key,
-                "Content-Type": "application/json",
-            }
-            body = {
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(endpoint, headers=headers, json=body, timeout=timeout) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"OpenAI Azure error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-
-            return res["choices"][0]["message"]["content"]
-
-        except Exception as err:
-            self._last_error = f"OpenAI Azure processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in OpenAI Azure API call:")
-            return None
-
-    # ---------------- Generic OpenAI ---------------------------------------------
     async def _generic_openai(self, prompt: str) -> str | None:
-        try:
-            endpoint = self._opt(CONF_GENERIC_OPENAI_ENDPOINT) 
-            if not endpoint:
-                raise ValueError("Generic OpenAI endpoint not configured")
+        endpoint = str(self._opt(CONF_GENERIC_OPENAI_ENDPOINT) or "").rstrip("/")
+        if not endpoint or not re.match(r"^https?://", endpoint):
+            raise ValueError("Generic OpenAI endpoint must be a full http(s) URL")
+        api_key = self._opt(CONF_GENERIC_OPENAI_API_KEY)
+        model = self._current_model("Generic OpenAI")
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        body = self._openai_compatible_body(
+            provider="Generic OpenAI",
+            model=model,
+            prompt=self._trim_prompt(prompt),
+            temperature=float(self._opt(CONF_GENERIC_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        )
+        response = await self._post_json(endpoint, headers=headers, body=body, provider_label="Generic OpenAI")
+        return self._extract_chat_content(response, "Generic OpenAI") if response else None
 
-            # Remove trailing slash if present
-            endpoint = endpoint.rstrip('/')
-            
-            # Ensure the endpoint is a valid URL
-            if not re.match(r"^https?://", endpoint):
-                raise ValueError("Generic OpenAI endpoint must start with http:// or https://")
-
-            api_key = self._opt(CONF_GENERIC_OPENAI_API_KEY)
-            model = self._opt(CONF_GENERIC_OPENAI_MODEL, DEFAULT_MODELS["Generic OpenAI"])
-            temperature = self._opt(CONF_GENERIC_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)
-            in_budget, out_budget = self._budgets()
-
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            headers = {"Content-Type": "application/json"}
-            if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
-
-            body = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-            timeout = aiohttp.ClientTimeout(total=900)
-            async with self.session.post(endpoint, headers=headers, json=body, timeout=timeout) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"Generic OpenAI error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-                
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-                
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-                
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-                
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-                
-            return res["choices"][0]["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"Generic OpenAI processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Generic OpenAI API call:")
-            return None
-
-    # ---------------- Anthropic ------------------------------------------------
     async def _anthropic(self, prompt: str) -> str | None:
-        try:
-            api_key = self._opt(CONF_ANTHROPIC_API_KEY)
-            model = self._opt(CONF_ANTHROPIC_MODEL, DEFAULT_MODELS["Anthropic"])
-            in_budget, out_budget = self._budgets()
-            temperature = self._opt(CONF_ANTHROPIC_TEMPERATURE, DEFAULT_TEMPERATURE)
-            if not api_key:
-                raise ValueError("Anthropic API key not configured")
-
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            headers = {
-                "X-API-Key": api_key,
-                "Content-Type": "application/json",
-                "anthropic-version": VERSION_ANTHROPIC,
-            }
-            body = {
-                "model": model,
-                "messages": [
-                    {"role": "user", "content": [{"type": "text", "text": prompt}]}
-                ],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(
-                ENDPOINT_ANTHROPIC, headers=headers, json=body, timeout=timeout
-            ) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"Anthropic error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "content" not in res:
-                raise ValueError(f"Response missing 'content' array: {res}")
-                
-            if not res["content"] or not isinstance(res["content"], list):
-                raise ValueError(f"Empty or invalid 'content' array: {res}")
-                
-            if "text" not in res["content"][0]:
-                raise ValueError(f"First choice missing 'text': {res['content'][0]}")
-                       
-            return res["content"][0]["text"]
-        
-        except Exception as err:
-            self._last_error = f"Anthropic processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Anthropic API call:")
+        api_key = self._opt(CONF_ANTHROPIC_API_KEY)
+        if not api_key:
+            raise ValueError("Anthropic API key not configured")
+        _, out_budget = self._budgets()
+        model = self._current_model("Anthropic")
+        body: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": [{"type": "text", "text": self._trim_prompt(prompt)}]}],
+            "max_tokens": out_budget,
+            "temperature": float(self._opt(CONF_ANTHROPIC_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        }
+        response = await self._post_json(
+            ENDPOINT_ANTHROPIC,
+            headers={"x-api-key": api_key, "Content-Type": "application/json", "anthropic-version": VERSION_ANTHROPIC},
+            body=body,
+            provider_label="Anthropic",
+        )
+        if not response:
             return None
-                
+        self._last_response_metadata = {
+            "stop_reason": response.get("stop_reason"),
+            "usage": response.get("usage"),
+        }
+        content = response.get("content") or []
+        text_parts = [part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text"]
+        if text_parts:
+            return "".join(text_parts)
+        raise ValueError(f"Anthropic response missing text content: {response}")
 
-    # ---------------- Google ---------------------------------------------------
     async def _google(self, prompt: str) -> str | None:
-        try:
-            api_key = self._opt(CONF_GOOGLE_API_KEY)
-            model = self._opt(CONF_GOOGLE_MODEL, DEFAULT_MODELS["Google"])
-            in_budget, out_budget = self._budgets()
-            temperature = self._opt(CONF_GOOGLE_TEMPERATURE, DEFAULT_TEMPERATURE)
-            if not api_key:
-                raise ValueError("Google API key not configured")
-
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            body = {
-                "contents": [{"parts": [{"text": prompt}]}],
-                "generationConfig": {
-                    "temperature": temperature,
-                    "maxOutputTokens": out_budget,
-                    "topK": 40,
-                    "topP": 0.95,
-                },
-            }
-            endpoint = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(endpoint, json=body, timeout=timeout) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"Google error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "candidates" not in res:
-                raise ValueError(f"Response missing 'candidates' array: {res}")
-                
-            if not res["candidates"] or not isinstance(res["candidates"], list):
-                raise ValueError(f"Empty or invalid 'candidates' array: {res}")
-                
-            if "content" not in res["candidates"][0]:
-                raise ValueError(f"First choice missing 'content': {res['candidates'][0]}")
-                
-            if "parts" not in res["candidates"][0]["content"]:
-                raise ValueError(f"content missing 'parts': {res['candidates'][0]['message']}")
-            
-            if not res["candidates"][0]["content"]["parts"] or not isinstance(res["candidates"][0]["content"]["parts"], list):
-                raise ValueError(f"Empty or invalid 'parts' array: {res['candidates'][0]['content']}")
-            
-            if "text" not in res["candidates"][0]["content"]["parts"][0]:
-                raise ValueError(f"parts missing 'text': {res['candidates'][0]['content']['parts']}")
-            
-                
-            return res["candidates"][0]["content"]["parts"][0]["text"]
-        
-        except Exception as err:
-            self._last_error = f"Google processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Google API call:")
+        api_key = self._opt(CONF_GOOGLE_API_KEY)
+        if not api_key:
+            raise ValueError("Google API key not configured")
+        _, out_budget = self._budgets()
+        model = self._current_model("Google")
+        generation_config: dict[str, Any] = {
+            "temperature": float(self._opt(CONF_GOOGLE_TEMPERATURE, DEFAULT_TEMPERATURE)),
+            "maxOutputTokens": out_budget,
+        }
+        if supports_json_schema("Google", model):
+            generation_config["responseMimeType"] = "application/json"
+            generation_config["responseSchema"] = json_schema_response_format()["json_schema"]["schema"]
+        body = {"contents": [{"parts": [{"text": self._trim_prompt(prompt)}]}], "generationConfig": generation_config}
+        endpoint = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
+        response = await self._post_json(endpoint, body=body, provider_label="Google")
+        if not response:
             return None
-                
-    # ---------------- Groq -----------------------------------------------------
+        candidates = response.get("candidates") or []
+        if not candidates:
+            raise ValueError(f"Google response missing candidates: {response}")
+        self._last_response_metadata = {
+            "finish_reason": candidates[0].get("finishReason"),
+            "usage": response.get("usageMetadata"),
+        }
+        parts = candidates[0].get("content", {}).get("parts", [])
+        text_parts = [part.get("text", "") for part in parts if isinstance(part, dict)]
+        return "".join(text_parts) if text_parts else None
+
     async def _groq(self, prompt: str) -> str | None:
-        try:
-            api_key = self._opt(CONF_GROQ_API_KEY)
-            model = self._opt(CONF_GROQ_MODEL, DEFAULT_MODELS["Groq"])
-            temperature = self._opt(CONF_GROQ_TEMPERATURE, DEFAULT_TEMPERATURE)
-            in_budget, out_budget = self._budgets()
-            if not api_key:
-                raise ValueError("Groq API key not configured")
+        api_key = self._opt(CONF_GROQ_API_KEY)
+        if not api_key:
+            raise ValueError("Groq API key not configured")
+        model = self._current_model("Groq")
+        body = self._openai_compatible_body(
+            provider="Groq",
+            model=model,
+            prompt=self._trim_prompt(prompt),
+            temperature=float(self._opt(CONF_GROQ_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        )
+        response = await self._post_json(
+            ENDPOINT_GROQ,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            body=body,
+            provider_label="Groq",
+        )
+        return self._extract_chat_content(response, "Groq") if response else None
 
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            body = {
-                "model": model,
-                "messages": [
-                    {"role": "user", "content": [{"type": "text", "text": prompt}]}
-                ],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(
-                ENDPOINT_GROQ, headers=headers, json=body, timeout=timeout
-            ) as resp:
-                if resp.status != 200:
-                    self._last_error = f"Groq error {resp.status}: {await resp.text()}"
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-                
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-                
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-                
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-                
-            return res["choices"][0]["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"Groq processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Groq API call:")
-            return None
-
-    # ---------------- LocalAI --------------------------------------------------
     async def _localai(self, prompt: str) -> str | None:
-        try:
-            ip = self._opt(CONF_LOCALAI_IP_ADDRESS)
-            port = self._opt(CONF_LOCALAI_PORT)
-            https = self._opt(CONF_LOCALAI_HTTPS, False)
-            model = self._opt(CONF_LOCALAI_MODEL, DEFAULT_MODELS["LocalAI"])
-            temperature = self._opt(CONF_LOCALAI_TEMPERATURE, DEFAULT_TEMPERATURE)
-            in_budget, out_budget = self._budgets()
-            if not ip or not port:
-                raise ValueError("LocalAI not fully configured")
+        ip = self._opt(CONF_LOCALAI_IP_ADDRESS)
+        port = self._opt(CONF_LOCALAI_PORT)
+        if not ip or not port:
+            raise ValueError("LocalAI not fully configured")
+        proto = "https" if self._opt(CONF_LOCALAI_HTTPS, False) else "http"
+        endpoint = ENDPOINT_LOCALAI.format(protocol=proto, ip_address=ip, port=port)
+        model = self._current_model("LocalAI")
+        body = self._openai_compatible_body(
+            provider="LocalAI",
+            model=model,
+            prompt=self._trim_prompt(prompt),
+            temperature=float(self._opt(CONF_LOCALAI_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        )
+        response = await self._post_json(endpoint, body=body, provider_label="LocalAI")
+        return self._extract_chat_content(response, "LocalAI") if response else None
 
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            proto = "https" if https else "http"
-            endpoint = ENDPOINT_LOCALAI.format(protocol=proto, ip_address=ip, port=port)
-
-            body = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(endpoint, json=body, timeout=timeout) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"LocalAI error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-                
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-                
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-                
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-                
-            return res["choices"][0]["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"LocalAI processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in LocalAI API call:")
-            return None
-
-    # ---------------- Ollama ---------------------------------------------------
     async def _ollama(self, prompt: str) -> str | None:
-        try:
-            ip = self._opt(CONF_OLLAMA_IP_ADDRESS)
-            port = self._opt(CONF_OLLAMA_PORT)
-            https = self._opt(CONF_OLLAMA_HTTPS, False)
-            model = self._opt(CONF_OLLAMA_MODEL, DEFAULT_MODELS["Ollama"])
-            temperature = self._opt(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE)
-            disable_think = self._opt(CONF_OLLAMA_DISABLE_THINK, False)
-            in_budget, out_budget = self._budgets()
-            if not ip or not port:
-                raise ValueError("Ollama not fully configured")
-
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            proto = "https" if https else "http"
-            endpoint = ENDPOINT_OLLAMA.format(protocol=proto, ip_address=ip, port=port)
-
-            messages = []
-            if disable_think:
-                messages.append({"role": "system", "content": "/no_think"})
-            messages.append({"role": "user", "content": prompt})
-
-            body = {
-                "model": model,
-                "messages": messages,
-                "stream": False,
-                "options": {
-                    "temperature": temperature,
-                    "num_predict": out_budget,
-                },
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(endpoint, json=body, timeout=timeout) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"Ollama error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "message" not in res:
-                raise ValueError(f"Response missing 'message' array: {res}")
-                
-            if "content" not in res["message"]:
-                raise ValueError(f"Message missing 'content': {res['message']}")
-                
-            return res["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"Ollama processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Ollama API call:")            
+        ip = self._opt(CONF_OLLAMA_IP_ADDRESS)
+        port = self._opt(CONF_OLLAMA_PORT)
+        if not ip or not port:
+            raise ValueError("Ollama not fully configured")
+        proto = "https" if self._opt(CONF_OLLAMA_HTTPS, False) else "http"
+        endpoint = ENDPOINT_OLLAMA.format(protocol=proto, ip_address=ip, port=port)
+        messages = []
+        if self._opt(CONF_OLLAMA_DISABLE_THINK, False):
+            messages.append({"role": "system", "content": "/no_think"})
+        messages.append({"role": "user", "content": self._trim_prompt(prompt)})
+        _, out_budget = self._budgets()
+        body = {
+            "model": self._current_model("Ollama"),
+            "messages": messages,
+            "stream": False,
+            "options": {
+                "temperature": float(self._opt(CONF_OLLAMA_TEMPERATURE, DEFAULT_TEMPERATURE)),
+                "num_predict": out_budget,
+            },
+        }
+        response = await self._post_json(endpoint, body=body, provider_label="Ollama")
+        if not response:
             return None
+        self._last_response_metadata = {"done_reason": response.get("done_reason"), "usage": response.get("eval_count")}
+        return response.get("message", {}).get("content")
 
-    # ---------------- Custom‑endpoint OpenAI -------------------------------
     async def _custom_openai(self, prompt: str) -> str | None:
-        try:
-            endpoint = self._opt(CONF_CUSTOM_OPENAI_ENDPOINT) + "/v1/chat/completions"
-            if not endpoint:
-                raise ValueError("Custom OpenAI endpoint not configured")
-            
-            if not endpoint.endswith("/v1/chat/completions"):
-                endpoint = endpoint.rstrip("/") + "/v1/chat/completions"
+        endpoint = str(self._opt(CONF_CUSTOM_OPENAI_ENDPOINT) or "").rstrip("/")
+        if not endpoint:
+            raise ValueError("Custom OpenAI endpoint not configured")
+        if endpoint.endswith("/chat/completions"):
+            completions_endpoint = endpoint
+        elif endpoint.endswith("/v1"):
+            completions_endpoint = f"{endpoint}/chat/completions"
+        else:
+            completions_endpoint = f"{endpoint}/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        api_key = self._opt(CONF_CUSTOM_OPENAI_API_KEY)
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        model = self._current_model("Custom OpenAI")
+        body = self._openai_compatible_body(
+            provider="Custom OpenAI",
+            model=model,
+            prompt=self._trim_prompt(prompt),
+            temperature=float(self._opt(CONF_CUSTOM_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        )
+        response = await self._post_json(completions_endpoint, headers=headers, body=body, provider_label="Custom OpenAI")
+        return self._extract_chat_content(response, "Custom OpenAI") if response else None
 
-            api_key  = self._opt(CONF_CUSTOM_OPENAI_API_KEY)
-            model    = self._opt(CONF_CUSTOM_OPENAI_MODEL, DEFAULT_MODELS["Custom OpenAI"])
-            temperature = self._opt(CONF_CUSTOM_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE)
-            in_budget, out_budget = self._budgets()
-
-
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            headers = {"Content-Type": "application/json"}
-            if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
-
-            body = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-            timeout = aiohttp.ClientTimeout(total=900)
-            async with self.session.post(endpoint, headers=headers, json=body, timeout=timeout) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"Custom OpenAI error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-                
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-                
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-                
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-                
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-                
-            return res["choices"][0]["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"Custom OpenAI processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Custom OpenAI API call:")
-            return None
-
-    # ---------------- Mistral ----------------------------------------------
     async def _mistral(self, prompt: str) -> str | None:
-        try:
-            api_key = self._opt(CONF_MISTRAL_API_KEY)
-            model = self._opt(CONF_MISTRAL_MODEL, DEFAULT_MODELS["Mistral AI"])
-            temperature = self._opt(CONF_MISTRAL_TEMPERATURE, DEFAULT_TEMPERATURE)
-            in_budget, out_budget = self._budgets()
-            if not api_key:
-                raise ValueError("Mistral API key not configured")
+        api_key = self._opt(CONF_MISTRAL_API_KEY)
+        if not api_key:
+            raise ValueError("Mistral API key not configured")
+        model = self._current_model("Mistral AI")
+        body = self._openai_compatible_body(
+            provider="Mistral AI",
+            model=model,
+            prompt=self._trim_prompt(prompt),
+            temperature=float(self._opt(CONF_MISTRAL_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        )
+        response = await self._post_json(
+            ENDPOINT_MISTRAL,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            body=body,
+            provider_label="Mistral",
+        )
+        return self._extract_chat_content(response, "Mistral") if response else None
 
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            }
-            body = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": temperature,
-                "max_tokens": out_budget,
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(
-                ENDPOINT_MISTRAL, headers=headers, json=body, timeout=timeout
-            ) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"Mistral error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-                
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-                
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-                
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-                
-            return res["choices"][0]["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"Mistral processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Mistral API call:")
-            return None
-
-    # ---------------- Perplexity -------------------------------------------
     async def _perplexity(self, prompt: str) -> str | None:
-        try:
-            api_key = self._opt(CONF_PERPLEXITY_API_KEY)
-            model = self._opt(CONF_PERPLEXITY_MODEL, DEFAULT_MODELS["Perplexity AI"])
-            temperature = self._opt(CONF_PERPLEXITY_TEMPERATURE, DEFAULT_TEMPERATURE)
-            in_budget, out_budget = self._budgets()
-            if not api_key:
-                raise ValueError("Perplexity API key not configured")
+        api_key = self._opt(CONF_PERPLEXITY_API_KEY)
+        if not api_key:
+            raise ValueError("Perplexity API key not configured")
+        model = self._current_model("Perplexity AI")
+        body = self._openai_compatible_body(
+            provider="Perplexity AI",
+            model=model,
+            prompt=self._trim_prompt(prompt),
+            temperature=float(self._opt(CONF_PERPLEXITY_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        )
+        response = await self._post_json(
+            ENDPOINT_PERPLEXITY,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json", "Accept": "application/json"},
+            body=body,
+            provider_label="Perplexity",
+        )
+        return self._extract_chat_content(response, "Perplexity") if response else None
 
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            }
-            body = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": out_budget,
-                "temperature": temperature,
-            }
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(
-                ENDPOINT_PERPLEXITY, headers=headers, json=body, timeout=timeout
-            ) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"Perplexity error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-                
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-                
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-                
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-                
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(f"Message missing 'content': {res['choices'][0]['message']}")
-                
-            return res["choices"][0]["message"]["content"]
-        
-        except Exception as err:
-            self._last_error = f"Perplexity processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in Perplexity API call:")
-            return None
-
-    # ---------------- OpenRouter -------------------------------------------
     async def _openrouter(self, prompt: str) -> str | None:
-        try:
-            api_key = self._opt(CONF_OPENROUTER_API_KEY)
-            model = self._opt(CONF_OPENROUTER_MODEL, DEFAULT_MODELS["OpenRouter"])
-            reasoning_max_tokens = self._opt(CONF_OPENROUTER_REASONING_MAX_TOKENS, 0)
-            in_budget, out_budget = self._budgets()
-
-            if not api_key:
-                raise ValueError("OpenRouter API key not configured")
-
-            if len(prompt) // 4 > in_budget:
-                prompt = prompt[: in_budget * 4]
-
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            }
-            body = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": out_budget,
-                "temperature": self._opt(
-                    CONF_OPENROUTER_TEMPERATURE, DEFAULT_TEMPERATURE
-                ),
-            }
-
-            if reasoning_max_tokens > 0:
-                body["reasoning"] = {"max_tokens": reasoning_max_tokens}
-
-            timeout = aiohttp.ClientTimeout(total=900)
-
-            async with self.session.post(
-                ENDPOINT_OPENROUTER, headers=headers, json=body, timeout=timeout
-            ) as resp:
-                if resp.status != 200:
-                    self._last_error = (
-                        f"OpenRouter error {resp.status}: {await resp.text()}"
-                    )
-                    _LOGGER.error(self._last_error)
-                    return None
-
-                res = await resp.json()
-
-            if not isinstance(res, dict):
-                raise ValueError(f"Unexpected response format: {res}")
-
-            if "choices" not in res:
-                raise ValueError(f"Response missing 'choices' array: {res}")
-
-            if not res["choices"] or not isinstance(res["choices"], list):
-                raise ValueError(f"Empty or invalid 'choices' array: {res}")
-
-            if "message" not in res["choices"][0]:
-                raise ValueError(f"First choice missing 'message': {res['choices'][0]}")
-
-            if "content" not in res["choices"][0]["message"]:
-                raise ValueError(
-                    f"Message missing 'content': {res['choices'][0]['message']}"
-                )
-
-            return res["choices"][0]["message"]["content"]
-
-        except Exception as err:
-            self._last_error = f"OpenRouter processing error: {str(err)}"
-            _LOGGER.error(self._last_error)
-            # Log stack trace for unexpected errors
-            _LOGGER.exception("Unexpected error in OpenRouter API call:")
-            return None
+        api_key = self._opt(CONF_OPENROUTER_API_KEY)
+        if not api_key:
+            raise ValueError("OpenRouter API key not configured")
+        model = self._current_model("OpenRouter")
+        extra: dict[str, Any] = {}
+        reasoning_max_tokens = int(self._opt(CONF_OPENROUTER_REASONING_MAX_TOKENS, 0))
+        if reasoning_max_tokens > 0:
+            extra["reasoning"] = {"max_tokens": reasoning_max_tokens}
+        body = self._openai_compatible_body(
+            provider="OpenRouter",
+            model=model,
+            prompt=self._trim_prompt(prompt),
+            temperature=float(self._opt(CONF_OPENROUTER_TEMPERATURE, DEFAULT_TEMPERATURE)),
+            extra=extra,
+        )
+        response = await self._post_json(
+            ENDPOINT_OPENROUTER,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            body=body,
+            provider_label="OpenRouter",
+        )
+        return self._extract_chat_content(response, "OpenRouter") if response else None

--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -3,7 +3,7 @@
   "name": "AI Automation Suggester",
   "codeowners": ["@ITSpecialist111"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["http"],
   "documentation": "https://github.com/ITSpecialist111/ai_automation_suggester",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ITSpecialist111/ai_automation_suggester/issues",

--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -13,5 +13,5 @@
     "pyyaml>=6.0",
     "voluptuous>=0.13.1"
   ],
-  "version": "1.4.2"
+  "version": "1.5.0"
 }

--- a/custom_components/ai_automation_suggester/model_catalog.py
+++ b/custom_components/ai_automation_suggester/model_catalog.py
@@ -1,0 +1,457 @@
+"""Static model capability metadata for AI Automation Suggester.
+
+The catalog is intentionally conservative. Providers still allow custom model
+names, but known metadata lets the integration choose safer request parameters
+and warn users about stale defaults, preview models, and deprecated IDs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+STATUS_STABLE = "stable"
+STATUS_PREVIEW = "preview"
+STATUS_DEPRECATED = "deprecated"
+STATUS_CUSTOM = "custom"
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """Capabilities for a specific model or model family."""
+
+    model: str
+    label: str = ""
+    endpoint_family: str = "chat"
+    context_window: int | None = None
+    max_output_tokens: int | None = None
+    token_parameter: str = "max_tokens"
+    supports_structured_output: bool = False
+    supports_json_schema: bool = False
+    supports_reasoning: bool = False
+    omit_temperature: bool = False
+    status: str = STATUS_STABLE
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ProviderCatalog:
+    """Default model and known capabilities for a provider."""
+
+    provider: str
+    default_model: str
+    models: tuple[ModelCapabilities, ...]
+    supports_model_listing: bool = False
+    model_listing_url: str | None = None
+
+
+SUGGESTION_RESPONSE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "suggestions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                    "yaml": {"type": "string"},
+                    "entities_used": {"type": "array", "items": {"type": "string"}},
+                    "automation_ids_used": {"type": "array", "items": {"type": "string"}},
+                    "confidence": {"type": "number"},
+                    "warnings": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["title", "description", "yaml"],
+                "additionalProperties": True,
+            },
+        }
+    },
+    "required": ["suggestions"],
+    "additionalProperties": True,
+}
+
+
+OPENAI_MODELS = (
+    ModelCapabilities(
+        "gpt-5.5",
+        "GPT-5.5",
+        endpoint_family="responses",
+        token_parameter="max_output_tokens",
+        supports_structured_output=True,
+        supports_json_schema=True,
+        supports_reasoning=True,
+        omit_temperature=True,
+        notes=("Use the OpenAI Responses API.",),
+    ),
+    ModelCapabilities(
+        "gpt-5.5-pro",
+        "GPT-5.5 Pro",
+        endpoint_family="responses",
+        token_parameter="max_output_tokens",
+        supports_structured_output=True,
+        supports_json_schema=True,
+        supports_reasoning=True,
+        omit_temperature=True,
+        notes=("Highest-intelligence OpenAI option; expect higher latency and cost.",),
+    ),
+    ModelCapabilities(
+        "gpt-5.4-mini",
+        "GPT-5.4 Mini",
+        endpoint_family="responses",
+        token_parameter="max_output_tokens",
+        supports_structured_output=True,
+        supports_json_schema=True,
+        supports_reasoning=True,
+        omit_temperature=True,
+    ),
+    ModelCapabilities(
+        "gpt-5.4",
+        "GPT-5.4",
+        endpoint_family="responses",
+        token_parameter="max_output_tokens",
+        supports_structured_output=True,
+        supports_json_schema=True,
+        supports_reasoning=True,
+        omit_temperature=True,
+    ),
+    ModelCapabilities(
+        "gpt-4o-mini",
+        "GPT-4o Mini",
+        token_parameter="max_completion_tokens",
+        supports_structured_output=True,
+        supports_json_schema=True,
+    ),
+    ModelCapabilities(
+        "gpt-4.1-mini",
+        "GPT-4.1 Mini",
+        token_parameter="max_completion_tokens",
+        supports_structured_output=True,
+        supports_json_schema=True,
+    ),
+    ModelCapabilities(
+        "o3",
+        "o3",
+        token_parameter="max_completion_tokens",
+        supports_reasoning=True,
+        omit_temperature=True,
+    ),
+    ModelCapabilities(
+        "o4-mini",
+        "o4 Mini",
+        token_parameter="max_completion_tokens",
+        supports_reasoning=True,
+        omit_temperature=True,
+    ),
+)
+
+
+PROVIDER_CATALOGS: dict[str, ProviderCatalog] = {
+    "OpenAI": ProviderCatalog(
+        "OpenAI",
+        "gpt-5.4-mini",
+        OPENAI_MODELS,
+        True,
+        "https://api.openai.com/v1/models",
+    ),
+    "OpenAI Azure": ProviderCatalog(
+        "OpenAI Azure",
+        "gpt-5.4-mini",
+        OPENAI_MODELS,
+    ),
+    "Anthropic": ProviderCatalog(
+        "Anthropic",
+        "claude-sonnet-4-6",
+        (
+            ModelCapabilities(
+                "claude-opus-4-7",
+                "Claude Opus 4.7",
+                token_parameter="max_tokens",
+                supports_reasoning=True,
+                notes=("Use adaptive thinking; manual budget_tokens is not accepted.",),
+            ),
+            ModelCapabilities(
+                "claude-sonnet-4-6",
+                "Claude Sonnet 4.6",
+                token_parameter="max_tokens",
+                supports_reasoning=True,
+                notes=("Adaptive thinking is recommended for reasoning-heavy requests.",),
+            ),
+            ModelCapabilities("claude-haiku-4-5", "Claude Haiku 4.5"),
+            ModelCapabilities(
+                "claude-3-7-sonnet-latest",
+                "Claude 3.7 Sonnet Latest",
+                status=STATUS_DEPRECATED,
+                notes=("Prefer Claude Sonnet 4.6 for new configurations.",),
+            ),
+        ),
+        True,
+        "https://api.anthropic.com/v1/models",
+    ),
+    "Google": ProviderCatalog(
+        "Google",
+        "gemini-2.5-flash",
+        (
+            ModelCapabilities(
+                "gemini-2.5-flash",
+                "Gemini 2.5 Flash",
+                supports_structured_output=True,
+                supports_json_schema=True,
+            ),
+            ModelCapabilities(
+                "gemini-2.5-pro",
+                "Gemini 2.5 Pro",
+                supports_structured_output=True,
+                supports_json_schema=True,
+            ),
+            ModelCapabilities(
+                "gemini-3-flash-preview",
+                "Gemini 3 Flash Preview",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                status=STATUS_PREVIEW,
+            ),
+            ModelCapabilities(
+                "gemini-3.1-pro-preview",
+                "Gemini 3.1 Pro Preview",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                status=STATUS_PREVIEW,
+            ),
+            ModelCapabilities(
+                "gemini-2.0-flash",
+                "Gemini 2.0 Flash",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                status=STATUS_DEPRECATED,
+                notes=("Gemini 2.0 Flash is deprecated in current Gemini docs.",),
+            ),
+        ),
+        True,
+        "https://generativelanguage.googleapis.com/v1beta/models",
+    ),
+    "Groq": ProviderCatalog(
+        "Groq",
+        "llama-3.3-70b-versatile",
+        (
+            ModelCapabilities("llama-3.3-70b-versatile", "Llama 3.3 70B Versatile"),
+            ModelCapabilities("llama-3.1-8b-instant", "Llama 3.1 8B Instant"),
+            ModelCapabilities("openai/gpt-oss-120b", "GPT OSS 120B"),
+            ModelCapabilities("openai/gpt-oss-20b", "GPT OSS 20B"),
+            ModelCapabilities(
+                "llama3-8b-8192",
+                "Llama 3 8B 8192",
+                status=STATUS_DEPRECATED,
+                notes=("Use llama-3.1-8b-instant or llama-3.3-70b-versatile.",),
+            ),
+        ),
+        True,
+        "https://api.groq.com/openai/v1/models",
+    ),
+    "LocalAI": ProviderCatalog("LocalAI", "llama3", (), True),
+    "Ollama": ProviderCatalog("Ollama", "llama3.1", (), True),
+    "Custom OpenAI": ProviderCatalog("Custom OpenAI", "gpt-4o-mini", OPENAI_MODELS, True),
+    "Generic OpenAI": ProviderCatalog("Generic OpenAI", "gpt-4o-mini", OPENAI_MODELS, True),
+    "Mistral AI": ProviderCatalog(
+        "Mistral AI",
+        "mistral-small-latest",
+        (
+            ModelCapabilities(
+                "mistral-small-latest",
+                "Mistral Small Latest",
+                supports_structured_output=True,
+                supports_json_schema=True,
+            ),
+            ModelCapabilities(
+                "mistral-medium-latest",
+                "Mistral Medium Latest",
+                supports_structured_output=True,
+                supports_json_schema=True,
+            ),
+            ModelCapabilities(
+                "mistral-large-latest",
+                "Mistral Large Latest",
+                supports_structured_output=True,
+                supports_json_schema=True,
+            ),
+            ModelCapabilities(
+                "mistral-medium",
+                "Mistral Medium",
+                status=STATUS_DEPRECATED,
+                notes=("Prefer current -latest aliases or published dated IDs.",),
+            ),
+        ),
+        True,
+        "https://api.mistral.ai/v1/models",
+    ),
+    "Perplexity AI": ProviderCatalog(
+        "Perplexity AI",
+        "sonar",
+        (
+            ModelCapabilities("sonar", "Sonar", supports_structured_output=True, supports_json_schema=True),
+            ModelCapabilities(
+                "sonar-pro",
+                "Sonar Pro",
+                supports_structured_output=True,
+                supports_json_schema=True,
+            ),
+            ModelCapabilities(
+                "sonar-reasoning-pro",
+                "Sonar Reasoning Pro",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                supports_reasoning=True,
+            ),
+            ModelCapabilities(
+                "sonar-deep-research",
+                "Sonar Deep Research",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                supports_reasoning=True,
+                notes=("Expect higher latency for research workflows.",),
+            ),
+        ),
+    ),
+    "OpenRouter": ProviderCatalog(
+        "OpenRouter",
+        "openai/gpt-5.4-mini",
+        (
+            ModelCapabilities(
+                "openai/gpt-5.5",
+                "OpenAI GPT-5.5 via OpenRouter",
+                token_parameter="max_tokens",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                supports_reasoning=True,
+                omit_temperature=True,
+            ),
+            ModelCapabilities(
+                "openai/gpt-5.4-mini",
+                "OpenAI GPT-5.4 Mini via OpenRouter",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                supports_reasoning=True,
+                omit_temperature=True,
+            ),
+            ModelCapabilities(
+                "anthropic/claude-opus-4.7",
+                "Claude Opus 4.7 via OpenRouter",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                supports_reasoning=True,
+            ),
+            ModelCapabilities(
+                "anthropic/claude-sonnet-4.6",
+                "Claude Sonnet 4.6 via OpenRouter",
+                supports_structured_output=True,
+                supports_json_schema=True,
+                supports_reasoning=True,
+            ),
+        ),
+        True,
+        "https://openrouter.ai/api/v1/models",
+    ),
+}
+
+
+def get_provider_catalog(provider: str) -> ProviderCatalog | None:
+    """Return the static catalog for a provider."""
+
+    return PROVIDER_CATALOGS.get(provider)
+
+
+def get_default_model(provider: str) -> str:
+    """Return the recommended default model for a provider."""
+
+    catalog = get_provider_catalog(provider)
+    return catalog.default_model if catalog else ""
+
+
+def get_model_capabilities(provider: str, model: str | None) -> ModelCapabilities:
+    """Return known capabilities for a selected model.
+
+    Unknown user-supplied model names remain valid and are treated as custom chat
+    models with conservative OpenAI-compatible defaults.
+    """
+
+    selected = model or get_default_model(provider)
+    catalog = get_provider_catalog(provider)
+    if catalog:
+        for item in catalog.models:
+            if item.model == selected:
+                return item
+        for item in catalog.models:
+            if selected.startswith(item.model.rstrip("*")):
+                return item
+
+    if provider in {"OpenAI", "OpenAI Azure", "Custom OpenAI", "Generic OpenAI"}:
+        if selected.startswith(("gpt-5", "o3", "o4")):
+            return ModelCapabilities(
+                selected,
+                endpoint_family="responses" if provider == "OpenAI" else "chat",
+                token_parameter="max_output_tokens" if provider == "OpenAI" else "max_completion_tokens",
+                supports_structured_output=provider == "OpenAI",
+                supports_json_schema=provider == "OpenAI",
+                supports_reasoning=True,
+                omit_temperature=True,
+            )
+        if selected.startswith(("gpt-4o", "gpt-4.1")):
+            return ModelCapabilities(
+                selected,
+                token_parameter="max_completion_tokens",
+                supports_structured_output=True,
+                supports_json_schema=True,
+            )
+
+    return ModelCapabilities(selected, status=STATUS_CUSTOM)
+
+
+def model_uses_responses_api(provider: str, model: str | None) -> bool:
+    """Return True when the model should use OpenAI's Responses API."""
+
+    return provider == "OpenAI" and get_model_capabilities(provider, model).endpoint_family == "responses"
+
+
+def chat_token_parameter(provider: str, model: str | None) -> str:
+    """Return the correct token limit parameter for chat-compatible APIs."""
+
+    capabilities = get_model_capabilities(provider, model)
+    if capabilities.token_parameter == "max_output_tokens":
+        return "max_completion_tokens"
+    return capabilities.token_parameter
+
+
+def should_send_temperature(provider: str, model: str | None) -> bool:
+    """Return False for models known to reject custom temperature settings."""
+
+    return not get_model_capabilities(provider, model).omit_temperature
+
+
+def supports_json_schema(provider: str, model: str | None) -> bool:
+    """Return True if this provider/model should receive JSON schema requests."""
+
+    return get_model_capabilities(provider, model).supports_json_schema
+
+
+def json_schema_response_format() -> dict:
+    """Return an OpenAI-compatible JSON schema response_format block."""
+
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "automation_suggestions",
+            "strict": False,
+            "schema": SUGGESTION_RESPONSE_SCHEMA,
+        },
+    }
+
+
+def compatibility_warnings(provider: str, model: str | None) -> list[str]:
+    """Return user-facing warnings for the selected provider/model."""
+
+    capabilities = get_model_capabilities(provider, model)
+    warnings: list[str] = []
+    if capabilities.status == STATUS_PREVIEW:
+        warnings.append(f"{capabilities.model} is a preview model and may change without notice.")
+    if capabilities.status == STATUS_DEPRECATED:
+        warnings.append(f"{capabilities.model} is deprecated; choose a current model when possible.")
+    warnings.extend(capabilities.notes)
+    return warnings

--- a/custom_components/ai_automation_suggester/sensor.py
+++ b/custom_components/ai_automation_suggester/sensor.py
@@ -54,6 +54,7 @@ from .const import (
     SENSOR_KEY_OUTPUT_TOKENS,
     SENSOR_KEY_MODEL,
     SENSOR_KEY_LAST_ERROR,
+    SENSOR_KEY_HISTORY_COUNT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -113,6 +114,13 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         icon="mdi:alert-circle-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    SensorEntityDescription(
+        key=SENSOR_KEY_HISTORY_COUNT,
+        name="Suggestion History Count",
+        icon="mdi:history",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 )
 
 async def async_setup_entry(
@@ -149,6 +157,8 @@ async def async_setup_entry(
             entities.append(AIModelSensor(coordinator, entry, specific_description))
         elif description.key == SENSOR_KEY_LAST_ERROR:
             entities.append(AILastErrorSensor(coordinator, entry, specific_description))
+        elif description.key == SENSOR_KEY_HISTORY_COUNT:
+            entities.append(AIHistoryCountSensor(coordinator, entry, specific_description))
         else:
             entities.append(AIBaseSensor(coordinator, entry, specific_description))
 
@@ -235,6 +245,8 @@ class AISuggestionsSensor(AIBaseSensor):
             "entities_processed": [],
             "provider": self._entry.data.get(CONF_PROVIDER, "unknown"),
             "entities_processed_count": 0,
+            "suggestion_count": 0,
+            "warnings": [],
         }
 
     async def async_added_to_hass(self) -> None:
@@ -268,7 +280,11 @@ class AISuggestionsSensor(AIBaseSensor):
             "last_update": data.get("last_update"),
             "entities_processed": data.get("entities_processed", []),
             "provider": self._entry.data.get(CONF_PROVIDER, "unknown"),
+            "model": data.get("model"),
             "entities_processed_count": len(data.get("entities_processed", [])),
+            "suggestion": data.get("suggestion"),
+            "suggestion_count": data.get("suggestion_count", 0),
+            "warnings": data.get("warnings", []),
         }
 
 # ─────────────────────────────────────────────────────────────
@@ -304,6 +320,10 @@ class AIProviderStatusSensor(AIBaseSensor):
         self._attr_extra_state_attributes = {
             "last_error_message": data.get("last_error", None),
             "last_attempted_update": data.get("last_update"),
+            "provider": data.get("provider", self._provider_name),
+            "model": data.get("model"),
+            "warnings": data.get("warnings", []),
+            "response_metadata": data.get("response_metadata", {}),
         }
 
 # ─────────────────────────────────────────────────────────────
@@ -409,4 +429,27 @@ class AILastErrorSensor(AIBaseSensor):
         self._attr_native_value = str(last_error) if last_error else "No Error"
         self._attr_extra_state_attributes = {
              "last_error_timestamp": data.get("last_update") if last_error else None,
+        }
+
+
+class AIHistoryCountSensor(AIBaseSensor):
+    """Shows how many suggestions are retained in history."""
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        entry: ConfigEntry,
+        description: SensorEntityDescription,
+    ) -> None:
+        super().__init__(coordinator, entry, description)
+        self._update_state_and_attributes()
+
+    def _update_state_and_attributes(self) -> None:
+        """Update state from coordinator history data."""
+        data = self.coordinator.data or {}
+        self._attr_native_value = data.get("suggestion_count", 0)
+        self._attr_extra_state_attributes = {
+            "latest_suggestion_id": (data.get("suggestion") or {}).get("id"),
+            "latest_suggestion_status": (data.get("suggestion") or {}).get("status"),
         }

--- a/custom_components/ai_automation_suggester/services.yaml
+++ b/custom_components/ai_automation_suggester/services.yaml
@@ -29,9 +29,51 @@ generate_suggestions:
       name: Domains
       description: "List of domains to consider. If empty, consider all domains."
       required: false
-      default: {}
+      default: []
       selector:
-        object: {}
+        select:
+          multiple: true
+          custom_value: true
+          options:
+            - light
+            - switch
+            - sensor
+            - binary_sensor
+            - climate
+            - cover
+            - media_player
+            - lock
+            - alarm_control_panel
+    exclude_domains:
+      name: Exclude Domains
+      description: "Domains to exclude from analysis, even when all entities are considered."
+      required: false
+      default: []
+      selector:
+        select:
+          multiple: true
+          custom_value: true
+          options:
+            - automation
+            - update
+            - button
+            - event
+    exclude_entities:
+      name: Exclude Entities
+      description: "Specific entity IDs to exclude from analysis."
+      required: false
+      default: []
+      selector:
+        entity:
+          multiple: true
+    exclude_areas:
+      name: Exclude Areas
+      description: "Area IDs or area names to exclude from analysis."
+      required: false
+      default: []
+      selector:
+        area:
+          multiple: true
     entity_limit:
       name: Entity Limit
       description: "Maximum number of entities to consider (randomly selected from the chosen domains)."
@@ -62,3 +104,29 @@ generate_suggestions:
           min: 10
           max: 500
           mode: slider
+
+clear_history:
+  name: Clear Suggestion History
+  description: "Clear all stored AI automation suggestions."
+
+update_suggestion:
+  name: Update Suggestion
+  description: "Update the review status for a stored AI automation suggestion."
+  fields:
+    suggestion_id:
+      name: Suggestion ID
+      description: "The suggestion ID to update."
+      required: true
+      selector:
+        text: {}
+    status:
+      name: Status
+      description: "New review status for the suggestion."
+      required: true
+      selector:
+        select:
+          options:
+            - new
+            - accepted
+            - declined
+            - dismissed

--- a/custom_components/ai_automation_suggester/store.py
+++ b/custom_components/ai_automation_suggester/store.py
@@ -1,0 +1,79 @@
+"""Persistent suggestion history storage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DEFAULT_HISTORY_RETENTION, DOMAIN
+
+STORE_VERSION = 1
+STORE_KEY = f"{DOMAIN}.suggestions"
+STORE_DATA_KEY = "suggestions"
+HASS_STORE_KEY = "_suggestion_store"
+
+
+class SuggestionStore:
+    """Small wrapper around Home Assistant storage helper."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._store: Store[dict[str, Any]] = Store(hass, STORE_VERSION, STORE_KEY)
+        self._data: dict[str, Any] | None = None
+
+    async def _async_load(self) -> dict[str, Any]:
+        if self._data is None:
+            self._data = await self._store.async_load() or {STORE_DATA_KEY: []}
+            self._data.setdefault(STORE_DATA_KEY, [])
+        return self._data
+
+    async def async_list(self) -> list[dict[str, Any]]:
+        """Return stored suggestions, newest first."""
+
+        data = await self._async_load()
+        return list(data.get(STORE_DATA_KEY, []))
+
+    async def async_add_suggestions(
+        self,
+        suggestions: list[dict[str, Any]],
+        retention: int = DEFAULT_HISTORY_RETENTION,
+    ) -> list[dict[str, Any]]:
+        """Persist suggestions and return the new stored list."""
+
+        data = await self._async_load()
+        current = list(data.get(STORE_DATA_KEY, []))
+        data[STORE_DATA_KEY] = suggestions + current
+        if retention > 0:
+            data[STORE_DATA_KEY] = data[STORE_DATA_KEY][:retention]
+        await self._store.async_save(data)
+        return list(data[STORE_DATA_KEY])
+
+    async def async_update_status(self, suggestion_id: str, status: str) -> dict[str, Any] | None:
+        """Update a suggestion status such as accepted, declined, or dismissed."""
+
+        data = await self._async_load()
+        for suggestion in data.get(STORE_DATA_KEY, []):
+            if suggestion.get("id") == suggestion_id:
+                suggestion["status"] = status
+                await self._store.async_save(data)
+                return suggestion
+        return None
+
+    async def async_clear(self) -> None:
+        """Clear all stored suggestions."""
+
+        data = await self._async_load()
+        data[STORE_DATA_KEY] = []
+        await self._store.async_save(data)
+
+
+def async_get_suggestion_store(hass: HomeAssistant) -> SuggestionStore:
+    """Return the singleton suggestion store for this Home Assistant instance."""
+
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    store = domain_data.get(HASS_STORE_KEY)
+    if store is None:
+        store = SuggestionStore(hass)
+        domain_data[HASS_STORE_KEY] = store
+    return store

--- a/custom_components/ai_automation_suggester/strings.json
+++ b/custom_components/ai_automation_suggester/strings.json
@@ -204,7 +204,14 @@
           "generic_openai_validation_endpoint": "Validation URL (Generic OpenAI, should end with 'models')",
           "generic_openai_enable_validation": "Enable Validation (Generic OpenAI)",
           "max_input_tokens": "Max Input Tokens",
-          "max_output_tokens": "Max Output Tokens"
+          "max_output_tokens": "Max Output Tokens",
+          "custom_system_prompt": "Persistent Custom System Prompt",
+          "excluded_domains": "Excluded Domains",
+          "excluded_entities": "Excluded Entities",
+          "excluded_areas": "Excluded Areas",
+          "history_retention": "Suggestion History Retention",
+          "request_timeout": "Provider Request Timeout",
+          "openai_reasoning_effort": "OpenAI Reasoning Effort"
         },
         "description": "Adjust settings for your AI providers. Fields relevant to your configured provider will be used. Common settings like token limits are configured per provider."
       }
@@ -245,6 +252,36 @@
         "automation_limit": {
           "name": "Automation Limit",
           "description": "Maximum number of automations to analyze (default: 100)."
+        },
+        "exclude_domains": {
+          "name": "Exclude Domains",
+          "description": "Domains to exclude from analysis."
+        },
+        "exclude_entities": {
+          "name": "Exclude Entities",
+          "description": "Entity IDs to exclude from analysis."
+        },
+        "exclude_areas": {
+          "name": "Exclude Areas",
+          "description": "Areas to exclude from analysis."
+        }
+      }
+    },
+    "clear_history": {
+      "name": "Clear Suggestion History",
+      "description": "Clear all stored AI automation suggestions."
+    },
+    "update_suggestion": {
+      "name": "Update Suggestion",
+      "description": "Update the review status for a stored AI automation suggestion.",
+      "fields": {
+        "suggestion_id": {
+          "name": "Suggestion ID",
+          "description": "The suggestion ID to update."
+        },
+        "status": {
+          "name": "Status",
+          "description": "The new review status."
         }
       }
     }

--- a/custom_components/ai_automation_suggester/suggestions.py
+++ b/custom_components/ai_automation_suggester/suggestions.py
@@ -1,0 +1,200 @@
+"""Suggestion parsing and formatting helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+import yaml
+
+YAML_RE = re.compile(r"```(?:yaml|yml)\s*([\s\S]+?)\s*```", flags=re.IGNORECASE)
+JSON_RE = re.compile(r"```json\s*([\s\S]+?)\s*```", flags=re.IGNORECASE)
+
+
+STRUCTURED_OUTPUT_INSTRUCTIONS = """
+Return a JSON object with this shape and no surrounding Markdown:
+{
+  "suggestions": [
+    {
+      "title": "Short automation title",
+      "description": "Why this automation is useful and how it works",
+      "yaml": "Home Assistant automation YAML",
+      "entities_used": ["domain.entity_id"],
+      "automation_ids_used": [],
+      "confidence": 0.0,
+      "warnings": []
+    }
+  ]
+}
+Only reference entity_ids present in the prompt. Keep suggestions review-only;
+do not claim that automations have been created or changed.
+"""
+
+
+def _as_list(value: Any) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _try_json_loads(raw_response: str) -> dict | list | None:
+    """Try to decode model output as JSON, including fenced JSON."""
+
+    text = raw_response.strip()
+    fenced = JSON_RE.search(text)
+    if fenced:
+        text = fenced.group(1).strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            try:
+                return json.loads(text[start : end + 1])
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def _validate_yaml(yaml_code: str | None) -> list[str]:
+    warnings: list[str] = []
+    if not yaml_code:
+        warnings.append("No automation YAML was returned.")
+        return warnings
+    try:
+        parsed = yaml.safe_load(yaml_code)
+    except yaml.YAMLError as err:
+        warnings.append(f"Returned YAML could not be parsed: {err}")
+        return warnings
+    if parsed is None:
+        warnings.append("Returned YAML was empty after parsing.")
+    elif not isinstance(parsed, (dict, list)):
+        warnings.append("Returned YAML parsed to an unexpected scalar value.")
+    return warnings
+
+
+def _normalise_suggestion(
+    item: dict[str, Any],
+    *,
+    provider: str,
+    model: str,
+    created_at: datetime,
+    entities_processed: list[str],
+    inherited_warnings: list[str],
+    response_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    title = str(item.get("title") or "AI automation suggestion").strip()
+    description = str(item.get("description") or item.get("shortDescription") or "").strip()
+    yaml_code = item.get("yaml") or item.get("yaml_block") or item.get("yamlCode")
+    yaml_code = str(yaml_code).strip() if yaml_code else None
+    warnings = [str(w) for w in inherited_warnings]
+    warnings.extend(str(w) for w in _as_list(item.get("warnings")))
+    warnings.extend(_validate_yaml(yaml_code))
+
+    finish_reason = response_metadata.get("finish_reason")
+    if finish_reason in {"length", "max_tokens"}:
+        warnings.append("The provider reported a length finish reason; the suggestion may be truncated.")
+    if response_metadata.get("status") == "incomplete":
+        warnings.append("The provider returned an incomplete response.")
+
+    suggestion_id = str(item.get("id") or uuid4())
+    return {
+        "id": suggestion_id,
+        "title": title,
+        "shortDescription": description[:180] if description else title,
+        "detailedDescription": description,
+        "description": description,
+        "yamlCode": yaml_code,
+        "yaml_block": yaml_code,
+        "provider": provider,
+        "model": model,
+        "status": str(item.get("status") or "new"),
+        "created_at": created_at.isoformat(),
+        "entities_used": [str(e) for e in _as_list(item.get("entities_used"))],
+        "automation_ids_used": [str(a) for a in _as_list(item.get("automation_ids_used"))],
+        "entities_processed": entities_processed,
+        "confidence": item.get("confidence"),
+        "warnings": warnings,
+        "response_metadata": response_metadata,
+    }
+
+
+def parse_suggestion_response(
+    raw_response: str,
+    *,
+    provider: str,
+    model: str,
+    created_at: datetime,
+    entities_processed: list[str],
+    inherited_warnings: list[str] | None = None,
+    response_metadata: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Parse a provider response into stored suggestion dictionaries."""
+
+    inherited = inherited_warnings or []
+    metadata = response_metadata or {}
+    structured = _try_json_loads(raw_response)
+    if isinstance(structured, dict):
+        raw_items = structured.get("suggestions")
+        if raw_items is None:
+            raw_items = [structured]
+        elif isinstance(raw_items, dict):
+            raw_items = [raw_items]
+        elif not isinstance(raw_items, list):
+            raw_items = []
+        suggestions = [
+            _normalise_suggestion(
+                item if isinstance(item, dict) else {"description": str(item)},
+                provider=provider,
+                model=model,
+                created_at=created_at,
+                entities_processed=entities_processed,
+                inherited_warnings=inherited,
+                response_metadata=metadata,
+            )
+            for item in raw_items
+        ]
+        if suggestions:
+            return suggestions
+
+    yaml_match = YAML_RE.search(raw_response)
+    yaml_code = yaml_match.group(1).strip() if yaml_match else None
+    description = YAML_RE.sub("", raw_response).strip() if yaml_match else raw_response.strip()
+    return [
+        _normalise_suggestion(
+            {
+                "title": "AI automation suggestion",
+                "description": description,
+                "yaml": yaml_code,
+            },
+            provider=provider,
+            model=model,
+            created_at=created_at,
+            entities_processed=entities_processed,
+            inherited_warnings=inherited,
+            response_metadata=metadata,
+        )
+    ]
+
+
+def format_suggestion_notification(suggestion: dict[str, Any]) -> str:
+    """Render one suggestion for a Home Assistant notification."""
+
+    parts = [f"## {suggestion.get('title', 'AI automation suggestion')}"]
+    description = suggestion.get("description")
+    if description:
+        parts.append(str(description))
+    yaml_code = suggestion.get("yamlCode") or suggestion.get("yaml_block")
+    if yaml_code:
+        parts.append("```yaml\n" + str(yaml_code).strip() + "\n```")
+    warnings = suggestion.get("warnings") or []
+    if warnings:
+        parts.append("Warnings:\n" + "\n".join(f"- {warning}" for warning in warnings))
+    return "\n\n".join(parts)

--- a/custom_components/ai_automation_suggester/translations/en.json
+++ b/custom_components/ai_automation_suggester/translations/en.json
@@ -204,7 +204,14 @@
           "generic_openai_validation_endpoint": "Validation URL (Generic OpenAI, should end with 'models')",
           "generic_openai_enable_validation": "Enable Validation (Generic OpenAI)",
           "max_input_tokens": "Max Input Tokens",
-          "max_output_tokens": "Max Output Tokens"
+          "max_output_tokens": "Max Output Tokens",
+          "custom_system_prompt": "Persistent Custom System Prompt",
+          "excluded_domains": "Excluded Domains",
+          "excluded_entities": "Excluded Entities",
+          "excluded_areas": "Excluded Areas",
+          "history_retention": "Suggestion History Retention",
+          "request_timeout": "Provider Request Timeout",
+          "openai_reasoning_effort": "OpenAI Reasoning Effort"
         },
         "description": "Adjust settings for your AI providers. Fields relevant to your configured provider will be used. Common settings like token limits are configured per provider."
       }
@@ -245,6 +252,36 @@
         "automation_limit": {
           "name": "Automation Limit",
           "description": "Maximum number of automations to analyze (default: 100)."
+        },
+        "exclude_domains": {
+          "name": "Exclude Domains",
+          "description": "Domains to exclude from analysis."
+        },
+        "exclude_entities": {
+          "name": "Exclude Entities",
+          "description": "Entity IDs to exclude from analysis."
+        },
+        "exclude_areas": {
+          "name": "Exclude Areas",
+          "description": "Areas to exclude from analysis."
+        }
+      }
+    },
+    "clear_history": {
+      "name": "Clear Suggestion History",
+      "description": "Clear all stored AI automation suggestions."
+    },
+    "update_suggestion": {
+      "name": "Update Suggestion",
+      "description": "Update the review status for a stored AI automation suggestion.",
+      "fields": {
+        "suggestion_id": {
+          "name": "Suggestion ID",
+          "description": "The suggestion ID to update."
+        },
+        "status": {
+          "name": "Status",
+          "description": "The new review status."
         }
       }
     }

--- a/custom_components/ai_automation_suggester/www/ai_automation_suggester/ai-automation-suggester-card.js
+++ b/custom_components/ai_automation_suggester/www/ai_automation_suggester/ai-automation-suggester-card.js
@@ -1,8 +1,13 @@
-import { LitElement, html, css } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
-import { applyHass } from 'custom-card-helpers'; // For hass object
-@customElement('ai-automation-suggester-card')
-export class AiAutomationSuggesterCard extends LitElement {
+import { LitElement, html, css } from "lit";
+
+class AiAutomationSuggesterCard extends LitElement {
+  static properties = {
+    hass: { attribute: false },
+    suggestions: { state: true },
+    loading: { state: true },
+    error: { state: true },
+  };
+
   static styles = css`
     :host {
       display: block;
@@ -10,70 +15,96 @@ export class AiAutomationSuggesterCard extends LitElement {
     ha-card {
       padding: 16px;
     }
+    .toolbar {
+      align-items: center;
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
     ul {
       list-style: none;
+      margin: 0;
       padding: 0;
     }
     li {
-      margin-bottom: 16px;
-      border-bottom: 1px solid #eee;
-      padding-bottom: 16px;
+      border-top: 1px solid var(--divider-color, #ddd);
+      padding: 12px 0;
+    }
+    li:first-child {
+      border-top: 0;
     }
     pre {
-      background-color: #f0f0f0;
-      padding: 10px;
+      background: var(--code-editor-background-color, #f5f5f5);
+      border-radius: 6px;
       overflow-x: auto;
-      border-radius: 4px;
+      padding: 12px;
+      white-space: pre-wrap;
+    }
+    .meta {
+      color: var(--secondary-text-color);
+      font-size: 0.9em;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
       margin-top: 8px;
     }
-    .details {
-      display: none; /* Initially hidden */
-    }
-    .details[open] {
-      display: block;
-    }
     .error {
-      color: red;
+      color: var(--error-color, #b00020);
     }
   `;
-  @property({ type: Object }) hass; // Home Assistant object
-  @property({ type: Array }) suggestions = [];
-  @state() loading = true;
-  @state() error = null;
+
+  constructor() {
+    super();
+    this.suggestions = [];
+    this.loading = true;
+    this.error = null;
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.fetchData();
   }
+
+  setConfig(config) {
+    this.config = config;
+  }
+
   async fetchData() {
+    if (!this.hass) {
+      return;
+    }
     this.loading = true;
     this.error = null;
     try {
-      const response = await this.hass.callApi('GET', '/api/ai_automation_suggester/suggestions');
-      this.suggestions = response;
+      this.suggestions = await this.hass.callApi("GET", "ai_automation_suggester/suggestions");
     } catch (err) {
-      this.error = err.message || 'Failed to fetch suggestions.';
+      this.error = err.message || "Failed to fetch suggestions.";
     } finally {
       this.loading = false;
     }
   }
-  toggleDetails(suggestion) {
-    suggestion.showDetails = !suggestion.showDetails;
-    this.requestUpdate(); // Ensure re-render
+
+  async copyYaml(yaml) {
+    await navigator.clipboard.writeText(yaml || "");
+    this.dispatchEvent(
+      new CustomEvent("hass-notification", {
+        detail: { type: "info", message: "YAML copied to clipboard." },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
-  copyYaml(yaml) {
-    navigator.clipboard.writeText(yaml);
-    this.dispatchEvent(new CustomEvent('hass-notification', {
-      detail: {
-        type: 'info',
-        message: 'YAML code copied to clipboard!',
-      },
-    }));
-  }
+
   async handleSuggestionAction(suggestionId, action) {
     try {
-      const response = await this.hass.callApi('POST', `/api/ai_automation_suggester/${action}/${suggestionId}`);
+      const response = await this.hass.callApi(
+        "POST",
+        `ai_automation_suggester/${action}/${suggestionId}`,
+      );
       if (response.success) {
-        this.fetchData(); // Refresh suggestions after action
+        await this.fetchData();
       } else {
         this.error = response.error || `Failed to ${action} suggestion.`;
       }
@@ -81,48 +112,48 @@ export class AiAutomationSuggesterCard extends LitElement {
       this.error = err.message || `Failed to ${action} suggestion.`;
     }
   }
+
+  renderSuggestion(suggestion) {
+    const yamlCode = suggestion.yamlCode || suggestion.yaml_block || "";
+    return html`
+      <li>
+        <h3>${suggestion.title || "AI automation suggestion"}</h3>
+        <p>${suggestion.shortDescription || suggestion.description || "No description returned."}</p>
+        <p class="meta">
+          ${suggestion.provider || "Unknown provider"} - ${suggestion.model || "Unknown model"} -
+          ${suggestion.status || "new"}
+        </p>
+        ${yamlCode ? html`<pre><code>${yamlCode}</code></pre>` : html`<p class="meta">No YAML was returned.</p>`}
+        ${(suggestion.warnings || []).length
+          ? html`<p class="meta">${suggestion.warnings.join(" ")}</p>`
+          : ""}
+        <div class="actions">
+          <ha-button @click=${() => this.copyYaml(yamlCode)} .disabled=${!yamlCode}>Copy YAML</ha-button>
+          <ha-button @click=${() => this.handleSuggestionAction(suggestion.id, "accept")}>Accept</ha-button>
+          <ha-button @click=${() => this.handleSuggestionAction(suggestion.id, "decline")}>Decline</ha-button>
+          <ha-button @click=${() => this.handleSuggestionAction(suggestion.id, "dismiss")}>Dismiss</ha-button>
+        </div>
+      </li>
+    `;
+  }
+
   render() {
     return html`
       <ha-card>
-        <div>
+        <div class="toolbar">
           <h2>AI Automation Suggestions</h2>
-          ${this.loading
-            ? html`<p>Loading suggestions...</p>`
-            : this.error
-              ? html`<p class="error">Error: ${this.error}</p>`
-              : html`
-                  <ul>
-                    ${this.suggestions.map(suggestion => html`
-                      <li>
-                        <h3>${suggestion.title}</h3>
-                        <p>${suggestion.shortDescription}</p>
-                        <button @click="${() => this.toggleDetails(suggestion)}">Details</button>
-                        <div class="details" ?open="${suggestion.showDetails}">
-                          <p>${suggestion.detailedDescription}</p>
-                          <pre><code class="language-yaml">${suggestion.yamlCode}</code></pre>
-                          <button @click="${() => this.copyYaml(suggestion.yamlCode)}">Copy YAML</button>
-                          <button @click="${() => this.handleSuggestionAction(suggestion.id, 'accept')}">Accept</button>
-                          <button @click="${() => this.handleSuggestionAction(suggestion.id, 'decline')}">Decline</button>
-                        </div>
-                      </li>
-                    `)}
-                  </ul>
-                `}
+          <ha-button @click=${this.fetchData}>Refresh</ha-button>
         </div>
+        ${this.loading
+          ? html`<p>Loading suggestions...</p>`
+          : this.error
+            ? html`<p class="error">${this.error}</p>`
+            : this.suggestions.length
+              ? html`<ul>${this.suggestions.map((suggestion) => this.renderSuggestion(suggestion))}</ul>`
+              : html`<p>No stored suggestions yet.</p>`}
       </ha-card>
     `;
   }
-  setConfig(config) {
-    // Optional: Handle any configuration options passed to the card
-  }
-  set hass(hass) {
-    applyHass(this, hass);
-  }
-  get hass() {
-    return this._hass;
-  }
 }
-// Provide a fallback registration if the module is loaded directly
-if (customElements.get('ai-automation-suggester-card') === undefined) {
-  customElements.define('ai-automation-suggester-card', AiAutomationSuggesterCard);
-}
+
+customElements.define("ai-automation-suggester-card", AiAutomationSuggesterCard);

--- a/docs/PROJECT_UPGRADE_PLAN.md
+++ b/docs/PROJECT_UPGRADE_PLAN.md
@@ -1,0 +1,333 @@
+# AI Automation Suggester Upgrade Plan
+
+Date: 2026-05-03
+Repository reviewed: https://github.com/ITSpecialist111/ai_automation_suggester
+
+## Scope Reviewed
+
+- Local integration source under `custom_components/ai_automation_suggester`.
+- Repository metadata: `manifest.json`, `hacs.json`, `requirements.txt`, README, example automations, translations, workflows.
+- GitHub backlog: 100 issues through #153 and 25 pull requests through #155.
+- Active backlog at review time: 27 open issues and 2 open pull requests.
+
+## Current State
+
+The project is a Home Assistant custom integration that generates automation suggestions from entity, device, area, and automation context. It currently exposes one sensor platform, a `generate_suggestions` service, persistent notifications, configuration and options flows, example automations, translation files, and a Lovelace card file.
+
+The integration supports many providers directly in `coordinator.py`: OpenAI, Azure OpenAI, Anthropic, Google, Groq, LocalAI, Ollama, Custom OpenAI, Mistral, Perplexity, OpenRouter, and Generic OpenAI. This gives the project broad reach, but it also concentrates provider-specific request building, validation, response parsing, timeout behavior, token handling, and error handling in one large file.
+
+There are no test files in the repository. CI currently validates HACS and hassfest only. This means most regressions reported in issues are likely found by users after release rather than by automated checks.
+
+The custom Lovelace card currently calls `/api/ai_automation_suggester/suggestions` and `/api/ai_automation_suggester/{action}/{suggestionId}`, but no matching backend API views were found in the local integration. That card should either be backed by real storage/API endpoints or removed/replaced with dashboard snippets that use supported sensor attributes.
+
+## Model Catalog And API Compatibility Research
+
+Research date: 2026-05-03. Sources checked: official OpenAI model/API docs, Azure OpenAI model availability docs, Anthropic Claude model docs, Google Gemini API docs, Mistral model/API docs, Groq model docs, Perplexity model docs, and OpenRouter model/API metadata.
+
+### Key Findings
+
+- The user's examples are real current model families, but the exact provider IDs matter. OpenAI documents `gpt-5.5` as the current flagship model and Azure OpenAI also lists `gpt-5.5` with model version `2026-04-24`. Anthropic documents `claude-opus-4-7` and `claude-sonnet-4-6`; the phrase "Opus 47" should be treated as shorthand for the API ID `claude-opus-4-7`.
+- The current static defaults are already drifting. The integration defaults Google to `gemini-2.0-flash`, while current Gemini docs mark Gemini 2.0 Flash and Flash-Lite as deprecated and list Gemini 2.5 stable models plus Gemini 3/3.1 preview models.
+- A static `DEFAULT_MODELS` dictionary is not enough. Each provider should have a catalog refresh path, a stable fallback, and a user override. Provider modules should store model metadata such as context window, max output, endpoint family, structured-output support, reasoning/thinking support, preview/deprecated status, and unsupported parameters.
+- Model compatibility is now as much about request shape as model name. Newer reasoning models may reject or ignore parameters that older chat models accepted, and several providers distinguish chat completions, responses, messages, or generate-content APIs.
+- Structured output support is now broad enough to become the primary parsing strategy, but it is not uniform. OpenAI, Gemini, Mistral, Perplexity, and OpenRouter all expose JSON or JSON Schema modes with provider-specific names and caveats. A Markdown fenced YAML fallback is still needed for older/local models.
+
+### Current Model Families To Support
+
+| Provider | Current model families to plan for | Notes for this integration |
+| --- | --- | --- |
+| OpenAI | `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.3-*`, `gpt-5.2-*`, `gpt-5.1-*`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1-*`, `gpt-4o*`, `o3`, `o4-mini`, `gpt-oss-*` | Prefer Responses API for GPT-5.5/5.4 reasoning models. Chat Completions can remain as compatibility fallback. Use `max_output_tokens` for Responses and model-aware `max_completion_tokens`/`max_tokens` for chat-compatible routes. Do not blindly send `temperature` to reasoning models. |
+| Azure OpenAI | Same broad OpenAI families where region/quota permits, including `gpt-5.5`, `gpt-5.4-*`, `gpt-5.3-*`, `gpt-5.2-*`, `gpt-5.1-*`, `gpt-5-*`, `gpt-4.1-*`, `gpt-4o*`, `o-series`, and `gpt-oss-*` | Azure users deploy named deployments, not just model IDs. The config flow should distinguish deployment name from underlying model family and record API version, region, quota limitations, preview status, and whether the deployment supports Chat Completions or Responses. |
+| Anthropic | `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` / `claude-haiku-4-5`, plus legacy Claude 4.x and 3.7 models | Use the Models API when possible to query `max_input_tokens`, `max_tokens`, and capabilities. Opus 4.7 and later no longer accept manual extended thinking with `budget_tokens`; use adaptive thinking with effort. Thinking mode is not compatible with custom `temperature` or `top_k` changes. |
+| Google Gemini | `gemini-3.1-pro-preview`, `gemini-3-flash-preview`, `gemini-3.1-flash-lite-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, and `*-latest` aliases where documented | Replace the default away from deprecated `gemini-2.0-flash`. Gemini 3 docs recommend leaving `temperature` at default 1.0. Use `thinking_config` only where supported. Use `response_mime_type` and `response_json_schema` for structured output. |
+| Mistral | Mistral Large 3, Mistral Medium 3.5/3.1, Mistral Small 4, Ministral 3 14B/8B/3B, Devstral 2, Codestral, Magistral Medium 1.2 | Current code default `mistral-medium` should be reviewed against current aliases such as `mistral-small-latest` and published model IDs. Mistral supports `/v1/models`, `response_format` JSON object/schema modes, `reasoning_effort`, and model-dependent default temperature. |
+| Groq | `llama-3.3-70b-versatile`, `llama-3.1-8b-instant`, `openai/gpt-oss-120b`, `openai/gpt-oss-20b`, `groq/compound`, `groq/compound-mini`, plus preview models like Llama 4 Scout | Current default `llama3-8b-8192` is stale. Use Groq's `https://api.groq.com/openai/v1/models` endpoint when authenticated. Distinguish production models from preview models. |
+| Perplexity | `sonar`, `sonar-pro`, `sonar-reasoning-pro`, `sonar-deep-research` | Current default `sonar` remains recognizable, but the integration should expose search/reasoning/research model classes. Perplexity structured outputs use `response_format` JSON Schema and may have first-schema latency of 10-30 seconds, so timeout handling matters. |
+| OpenRouter | Dynamic provider-prefixed IDs such as `openai/gpt-5.5`, `anthropic/claude-opus-4.7`, `google/gemini-2.5-flash`, `mistralai/mistral-large-2512`, router aliases such as `openrouter/auto`, and latest-family aliases such as `~openai/gpt-latest` | Treat OpenRouter as a dynamic catalog provider. Use `/api/v1/models` to discover IDs, context length, max completion tokens, pricing, supported parameters, deprecations, and structured-output support. Its normalized response includes both `finish_reason` and `native_finish_reason`. |
+| LocalAI, Ollama, Open WebUI, Generic OpenAI-compatible | User-supplied model names | Do not validate against a fixed catalog. Probe `/models` or provider-specific endpoints where available, allow no-key local deployments, and make token/temperature/JSON-mode capabilities configurable or auto-detected. |
+
+### Compatibility Strategy
+
+- Add a `ModelCatalog` concept per provider. It should support static fallback entries, authenticated model listing where available, manual refresh, cache expiry, and a visible "last refreshed" diagnostic.
+- Store model capabilities separately from provider capabilities. A provider can support a feature while a specific model does not.
+- Add a model-aware request builder that maps the integration's generic generation settings to provider-specific parameters: `max_output_tokens`, `max_completion_tokens`, `max_tokens`, `thinking`, `thinking_config`, `reasoning`, `reasoning_effort`, `response_format`, `response_mime_type`, and `response_json_schema`.
+- Add a compatibility warning layer. If a selected model is preview, deprecated, missing structured output, missing JSON schema support, or likely to reject configured sampling parameters, show this in diagnostics and avoid sending unsafe parameters.
+- Keep stable default recommendations by provider, but prefer aliases only when the provider guarantees the alias behavior. For production defaults, prefer stable non-preview IDs over preview IDs unless the user explicitly opts into preview/latest aliases.
+- Add provider smoke tests around representative current models using mocked HTTP fixtures: OpenAI GPT-5.5 Responses, Azure OpenAI GPT-5.5 deployment, Claude Opus 4.7 adaptive thinking, Claude Sonnet 4.6, Gemini 2.5 stable structured output, Gemini 3 preview structured output, Mistral JSON schema, Groq production model, Perplexity Sonar structured output, and OpenRouter dynamic metadata.
+- Add a release checklist item to refresh model catalogs and mark deprecated defaults before every release.
+
+## Backlog Themes
+
+### Provider Compatibility
+
+Open issues show recurring provider breakage and endpoint rigidity:
+
+- Ollama/Open WebUI/custom endpoint issues: #116, #122, #132, #142, #144, #149.
+- OpenAI model parameter drift, especially GPT-5 style `max_completion_tokens`: #141.
+- Google/Gemini parsing and model compatibility: #130, #150, #152.
+- Anthropic validation/model compatibility: #153.
+- OpenRouter setup timeout/cancel behavior: #145.
+- New provider requests: Venice.ai #131, ZhipuAI via closed PR #129 and open PR #155.
+
+The code should move to a provider abstraction so each provider owns its endpoint shape, validation behavior, request parameters, timeout needs, response parser, and capability flags.
+
+### Home Assistant Platform Alignment
+
+Several issues point at Home Assistant API evolution and better native AI integration:
+
+- Migration/setup compatibility: #113, #128.
+- Use existing HA-configured LLM/conversation agents: #112.
+- Support AI Task and AI Buttons: #134.
+- Consider integration sub-entries: #136.
+
+This project should decide its minimum supported Home Assistant version. The README mentions 2023.5, while `hacs.json` requires 2024.1. A modernized roadmap should likely target a newer baseline if AI Task/sub-entry features become core requirements.
+
+### Suggestion Quality And Output Reliability
+
+Closed and open issues repeatedly mention truncated output, missing YAML, missing descriptions, no suggestions, or sensor attributes not updating: #8, #9, #37, #42, #61, #65, #78, #94, #96, #97, #123, #127, #152.
+
+The integration should stop relying only on "find the first fenced YAML block" parsing. It needs a structured response contract, validation, truncation detection, and a durable suggestion store.
+
+### User Control
+
+Users want more control over what is analyzed and how suggestions are generated:
+
+- Exclude domains, areas, and entities: #102.
+- Persist and recall previous suggestions: #109.
+- Persistent custom system prompt field: #139.
+- Earlier requests for skipping/ignoring suggestions and manual prompt flows: #24, #88, #89.
+
+These are core product features, not nice-to-haves. They make the integration safer, cheaper to run, and easier to trust.
+
+### Localization
+
+Localization is active and valuable, but incomplete:
+
+- Italian translation/output behavior: #133.
+- Czech translation request: #151.
+- Open PR #154 adds multilingual system prompts and Polish localization.
+
+The integration should separate UI translation from AI output language. UI strings belong in translation files; prompt/output language should be selected from the Home Assistant language or an explicit option.
+
+### Stability, Logs, And Diagnostics
+
+Issue #120 asks for log cleanup and stability help. More broadly, users need clear provider health, last request metadata, timeout information, and recoverable error messages. The current provider status sensor mostly infers status from coordinator data and suggestion presence, which is not enough for reliable diagnostics.
+
+## Open Pull Request Handling
+
+### PR #154: Multilingual system prompts and Polish localization
+
+This is a small, focused PR touching `const.py`, `coordinator.py`, `manifest.json`, and adding `translations/pl.json`. It should be reviewed first and likely merged or reimplemented after tests are added. The main review question is whether multilingual prompts belong in constants, translation files, or a prompt registry.
+
+Recommended action: accept the feature direction, add tests for language selection, and merge or port it into the prompt/output-language work.
+
+### PR #155: New providers and unified configuration/translation flow
+
+This is a large PR touching 21 files with major changes to config flow, coordinator, services, sensors, translations, and new docs. It overlaps many real backlog items: Venice.ai #131, Open WebUI/custom endpoint flexibility #122/#132, OpenRouter setup #145, and provider configuration cleanup.
+
+Recommended action: do not merge as one broad change until the provider abstraction and tests exist. Mine it for useful provider schemas, docs, and endpoint handling, then split it into smaller PRs: provider abstraction, Open WebUI/custom endpoint support, Venice/ZhipuAI providers, service enhancements, translation cleanup, and docs.
+
+## Target Architecture
+
+### Provider Layer
+
+Create a `providers/` package with a small shared contract:
+
+- `ProviderConfig`: normalized provider settings from config/options.
+- `ProviderCapabilities`: flags for OpenAI-compatible chat, Responses API support, streaming support, custom headers, endpoint validation, timeout defaults, model listing, model metadata, token parameter names, reasoning/thinking support, JSON/schema mode support, and content-type quirks.
+- `ModelCapabilities`: per-model metadata for context window, max output tokens, endpoint family, stable/preview/deprecated status, supported generation parameters, structured-output support, and known caveats.
+- `BaseProvider`: methods for `validate()`, `generate()`, `parse_response()`, and `redact_for_diagnostics()`.
+- Provider modules for OpenAI-compatible, Anthropic, Google, Ollama, OpenRouter, Mistral, Perplexity, and local/custom endpoints.
+
+This would remove the large dispatch dictionary and repeated response validation blocks from `coordinator.py`.
+
+### Suggestion Pipeline
+
+Split the current coordinator responsibilities:
+
+- `context.py`: collect entities, areas, devices, existing automations, and optional YAML file content.
+- `filters.py`: include/exclude domains, areas, devices, entities, disabled/unavailable entities, and hidden entities.
+- `prompt.py`: build prompt sections, select language, enforce input budgets, summarize oversized context.
+- `suggestions.py`: parse structured provider responses, validate YAML, record warnings, and store history.
+- `coordinator.py`: orchestrate refreshes and update sensors only.
+
+### Durable Suggestion Store
+
+Use Home Assistant's storage helper to keep recent suggestions with IDs, created timestamps, provider/model metadata, input scope, prompt summary, generated description, YAML block, parse warnings, user action state, and optional rating.
+
+This store would satisfy #109 and also provide the missing backend needed by the custom card.
+
+### Home Assistant Native AI Support
+
+Add a compatibility layer for Home Assistant-native AI paths:
+
+- Explore using configured conversation agents or AI Task entities for users who already manage provider credentials in Home Assistant (#112, #134).
+- Evaluate sub-entry support for provider/model variants once the minimum HA version supports it (#136).
+- Keep direct provider support for users who want this integration to be standalone.
+
+## Roadmap
+
+### Phase 0: Triage And Baseline
+
+Goal: make the project easier to maintain before changing behavior.
+
+- Add labels and milestones to GitHub: provider, config-flow, HA-compatibility, output-parsing, localization, UX, docs, tests.
+- Confirm the supported Home Assistant baseline and update README/HACS metadata to match.
+- Create reproducible fixtures for the highest-volume failures: provider response shape drift, timeout, truncated output, missing YAML, and config migration.
+- Add issue templates that ask for HA version, integration version, provider, model, endpoint type, logs, service call data, and whether the provider works outside this integration.
+
+### Phase 1: Safety, Compatibility, And Tests
+
+Goal: stop the most common regressions.
+
+- Add pytest coverage with `pytest-homeassistant-custom-component` for config flow, options flow, service handling, coordinator state updates, migration, and sensors.
+- Add mock provider tests for successful responses, API errors, invalid JSON, text/plain responses, empty choices, missing `message`, missing YAML, and truncated output.
+- Add linting/formatting CI, preferably Ruff plus existing hassfest/HACS checks.
+- Fix config entry migration to use supported Home Assistant update APIs rather than assigning `config_entry.version` directly.
+- Keep `async_forward_entry_setups` and remove stale compatibility assumptions around the older singular method.
+- Add coordinator locking so concurrent service calls cannot mutate shared prompt/filter settings mid-request.
+- Validate service data with a schema and normalize `domains` to a real list selector rather than a generic object.
+- Make the provider status sensor represent actual provider validation/request state, not simply whether suggestions exist.
+
+Primary issues covered: #113, #120, #123, #128, #143.
+
+### Phase 2: Provider Modernization
+
+Goal: make providers reliable and easier to extend.
+
+- Introduce the provider abstraction and move provider-specific code out of `coordinator.py`.
+- Support exact custom OpenAI-compatible URLs, optional validation URL, custom headers, optional API key, and Open WebUI base paths (#122, #132).
+- Add local provider timeout configuration, especially for Ollama and slow local hardware (#142).
+- Support Ollama/Open WebUI endpoint variants and content-type fallback for cloud models returning `text/plain` (#116, #144, #149).
+- Add model-aware OpenAI token parameter selection, including `max_completion_tokens` where needed (#141).
+- Add OpenAI Responses API support for `gpt-5.5`/`gpt-5.4` reasoning models, including `max_output_tokens`, `reasoning.effort`, incomplete response detection, and no blind `temperature` forwarding.
+- For Azure OpenAI, separate deployment name from model family and track API version, region availability, quota/preview status, and Chat Completions versus Responses support.
+- Harden Google/Gemini parsing and defaults for current Gemini models (#130, #150, #152).
+- Refresh Google defaults away from deprecated `gemini-2.0-flash`; prefer Gemini 2.5 stable defaults and document Gemini 3 preview opt-in behavior.
+- Refresh Anthropic validation defaults and docs for `claude-opus-4-7`, `claude-sonnet-4-6`, and `claude-haiku-4-5`; support the Anthropic Models API and adaptive thinking where available (#153).
+- Refresh Groq defaults away from stale Llama 3 8B IDs and distinguish production versus preview Groq models.
+- Refresh Mistral defaults and aliases for Large 3, Medium 3.5, Small 4, Ministral 3, Devstral 2, and Codestral.
+- Keep Perplexity `sonar` support but expose Sonar Pro, Sonar Reasoning Pro, and Sonar Deep Research as explicit choices with timeout guidance.
+- Treat OpenRouter as a dynamic catalog provider and use `/api/v1/models` metadata to filter models by context length, supported parameters, structured outputs, and deprecation/expiration.
+- Harden OpenRouter setup and request timeout behavior (#145).
+- Add provider plugin tests before adding Venice.ai or ZhipuAI (#131, #155, #129).
+
+Primary issues covered: #116, #122, #130, #131, #132, #141, #142, #144, #145, #149, #150, #153.
+
+### Phase 3: Context, Prompting, And Structured Output
+
+Goal: make suggestions useful, parsable, and repeatable.
+
+- Add include/exclude filters for domains, areas, devices, entities, disabled entities, hidden entities, and unavailable entities (#102).
+- Add a persistent custom system prompt option plus per-service extra prompt (#139).
+- Replace plain-text response parsing with a structured schema such as JSON containing `title`, `description`, `yaml`, `entities_used`, `automation_ids_used`, `confidence`, and `warnings`.
+- Ask providers to emit YAML as data, not only as a fenced Markdown block; use provider-native JSON/schema modes where available and keep Markdown parsing as fallback.
+- Add provider-specific structured-output adapters for OpenAI Responses/Chat Completions, Anthropic tool/JSON prompting fallback, Gemini `response_json_schema`, Mistral `response_format`, Perplexity `response_format`, and OpenRouter `response_format`.
+- Validate returned YAML enough to catch malformed automation snippets before surfacing them as ready-to-use.
+- Detect truncation from provider finish reasons or incomplete structured output and show a clear warning instead of silently storing partial suggestions.
+- Summarize or chunk context when input budgets are exceeded instead of cutting the prompt in the middle of entity text.
+- Add suggestion history with configurable retention (#109).
+- Add prompt/output language selection and review PR #154 in this phase (#133, #151, #154).
+
+Primary issues covered: #102, #109, #133, #139, #151, #152, #154.
+
+### Phase 4: User Experience And HA-Native Workflows
+
+Goal: make review and action easier inside Home Assistant.
+
+- Decide whether to keep the custom card. If kept, implement the missing backend API or websocket commands against the suggestion store.
+- Add services for `dismiss_suggestion`, `rate_suggestion`, `regenerate_suggestion`, `export_suggestion_yaml`, and `clear_history`.
+- Add dashboard examples that work without unsupported endpoints.
+- Explore AI Task/AI Buttons integration for on-demand "suggest automation for this entity/area/device" workflows (#134).
+- Explore using HA-configured conversation agents/LLMs to avoid duplicate API keys (#112).
+- Explore sub-entries for provider/model variants once the minimum HA version is high enough (#136).
+- Keep suggestions review-only; do not auto-create automations unless a future feature adds explicit, multi-step confirmation.
+
+Primary issues covered: #112, #134, #136, plus UX fallout from #57, #78, #96, #97, #127.
+
+### Phase 5: Documentation, Release, And Maintenance
+
+Goal: make releases predictable.
+
+- Rewrite README around the actual current workflow, provider matrix, privacy notes, and troubleshooting.
+- Add a model compatibility page covering stable defaults, preview opt-in, deprecated model warnings, provider-specific token parameters, and troubleshooting for model/API errors.
+- Document exactly what entity/automation data is sent to cloud providers and how local providers avoid that.
+- Document API key storage accurately for Home Assistant custom integrations.
+- Add provider setup guides for OpenAI-compatible endpoints, Open WebUI, Ollama, OpenRouter, Gemini, Anthropic, and Azure OpenAI.
+- Add a changelog and release checklist.
+- Update GitHub Actions versions and pin actions where appropriate.
+- Add a small compatibility matrix by integration version, HA version, provider, and known model quirks.
+- Refresh the provider/model matrix during every release and record the research date/source links.
+
+## Suggested Releases
+
+### 1.4.3 Patch Release
+
+- Fix config migration/setup compatibility.
+- Add custom system prompt option or correct README if it is intentionally service-only.
+- Add configurable local-provider timeout.
+- Fix OpenAI `max_completion_tokens` handling for newer models.
+- Add a safe short-term model default refresh for Google, Groq, Mistral, Anthropic, and OpenAI without removing user-selected custom models.
+- Fix obvious provider response parser bugs and better last-error surfacing.
+- Add Czech translation if the submitted file is usable.
+- Merge or port PR #154 if language selection tests pass.
+
+### 1.5.0 Foundation Release
+
+- Provider abstraction.
+- Model catalog and capability metadata.
+- Test suite and CI linting.
+- Exclusion filters.
+- Suggestion history storage.
+- Structured output parsing.
+- Backed custom card API or removal of the unsupported card.
+
+### 1.6.0 Home Assistant Native AI Release
+
+- AI Task/AI Button integration.
+- Optional reuse of configured HA conversation agents/LLMs.
+- Provider sub-entry evaluation or implementation.
+- Expanded provider support from split pieces of PR #155.
+
+### 2.0.0 Cleanup Release
+
+- Remove legacy config fields and deprecated behavior after migration support is proven.
+- Finalize stable internal provider APIs.
+- Rework dashboard/card UX around stored suggestions and explicit user review.
+
+## Issue Coverage Map
+
+| Area | Issues / PRs | Plan |
+| --- | --- | --- |
+| Exclusions | #102 | Phase 3 filters |
+| History | #109 | Phase 3 suggestion store |
+| HA-native AI | #112, #134, #136 | Phase 4 |
+| HA compatibility | #113, #128 | Phase 1 |
+| Local/custom endpoints | #116, #122, #132, #142, #144, #149 | Phase 2 |
+| Provider parsing/models | #130, #141, #145, #150, #153 | Phase 2 |
+| Model catalog churn | #130, #141, #150, #153 plus current model research | Phase 2 and Phase 5 |
+| New providers | #131, #129, #155 | Phase 2 after provider abstraction |
+| Localization | #133, #151, #154 | Phase 3 |
+| Prompt customization | #139 | Phase 3 or 1.4.3 patch |
+| No/truncated suggestions | #123, #127, #152 | Phase 1 and Phase 3 |
+| Already configured | #143 plus older #69/#74/#90 | Phase 1 config-flow cleanup |
+| Stability/logs | #120 | Phase 1 diagnostics, Phase 5 docs |
+
+## Risks And Decisions
+
+- Minimum Home Assistant version is the largest architectural decision. Supporting very old versions conflicts with AI Task and sub-entry work.
+- PR #155 is valuable but too broad to merge safely before test coverage and provider boundaries exist.
+- Cloud-provider privacy expectations need clearer documentation because entity names, states, attributes, areas, devices, and automations may be sent to providers.
+- Structured output will improve parsing, but providers vary in JSON-mode support. A fallback parser is still needed.
+- Latest model support should not be implemented as one more hardcoded constants update. The safer path is catalog metadata, capability-aware request building, and explicit warnings for preview/deprecated models.
+- Automatic automation creation should remain out of scope until validation, review, and explicit confirmation flows are mature.
+
+## Immediate Next Actions
+
+1. Add tests and CI linting before feature work.
+2. Fix migration/config-flow compatibility and provider status accuracy.
+3. Split provider logic out of `coordinator.py`.
+4. Add model catalog/capability metadata and refresh stale defaults before broad provider feature work.
+5. Implement exact/custom endpoint handling for OpenAI-compatible and Open WebUI users.
+6. Add exclusion filters, persistent custom prompt, and suggestion history.
+7. Review PR #154 for near-term merge and split PR #155 into smaller provider-focused changes.

--- a/docs/RELEASE_1.5.0.md
+++ b/docs/RELEASE_1.5.0.md
@@ -1,0 +1,29 @@
+# AI Automation Suggester 1.5.0
+
+This foundation release modernizes provider/model handling and makes suggestions easier to review, retain, and display in Home Assistant.
+
+## Highlights
+
+- Current model defaults and model capability metadata for OpenAI GPT-5-style models, Azure OpenAI deployments, Claude Sonnet/Opus 4.x, Gemini 2.5/3 preview, Groq, Mistral, Perplexity, OpenRouter, and local/OpenAI-compatible providers.
+- OpenAI Responses API support for GPT-5-style reasoning models with safer `max_output_tokens` and reasoning effort handling.
+- Structured output support with JSON-first parsing, fenced YAML fallback, YAML validation warnings, and truncation warnings.
+- Persistent suggestion history stored in Home Assistant storage.
+- New backend endpoints for the included Lovelace card:
+  - `GET /api/ai_automation_suggester/suggestions`
+  - `POST /api/ai_automation_suggester/{accept|decline|dismiss}/{suggestion_id}`
+- New services:
+  - `ai_automation_suggester.clear_history`
+  - `ai_automation_suggester.update_suggestion`
+- Persistent custom prompt, exclusion filters, request timeout, and history retention options.
+- Tests, changelog, issue templates, and CI scaffolding for safer future releases.
+
+## HACS Updates
+
+HACS detects updates from GitHub releases. After the `1.5.0` tag and GitHub release are published, HACS users should see the update in Home Assistant and can upgrade from HACS. A Home Assistant restart is still required after updating a custom integration.
+
+## Notes For Upgraders
+
+- Existing custom model names remain supported.
+- Some stale defaults were refreshed for new configurations. Existing configured model values are preserved unless the user changes them in options.
+- Suggestions are still review-only. The integration does not automatically create or modify automations.
+- Cloud providers may receive entity names, states, attributes, areas, device context, and automation metadata. Use local providers for local-only processing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501", "UP007", "UP045"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pytest
 pytest-cov==2.9.0
 pytest-homeassistant-custom-component
+pyyaml>=6.0
+ruff>=0.4.0

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,36 @@
+"""Tests for model catalog helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module(name: str):
+    path = Path(__file__).resolve().parents[1] / "custom_components" / "ai_automation_suggester" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+model_catalog = load_module("model_catalog")
+
+
+def test_openai_gpt_55_uses_responses_api():
+    assert model_catalog.model_uses_responses_api("OpenAI", "gpt-5.5") is True
+    assert model_catalog.should_send_temperature("OpenAI", "gpt-5.5") is False
+
+
+def test_deprecated_google_model_warns():
+    warnings = model_catalog.compatibility_warnings("Google", "gemini-2.0-flash")
+    assert any("deprecated" in warning.lower() for warning in warnings)
+
+
+def test_unknown_local_model_is_allowed_as_custom():
+    capabilities = model_catalog.get_model_capabilities("Ollama", "my-local-model")
+    assert capabilities.model == "my-local-model"
+    assert capabilities.status == model_catalog.STATUS_CUSTOM

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,0 +1,83 @@
+"""Tests for suggestion response parsing."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def load_module(name: str):
+    path = Path(__file__).resolve().parents[1] / "custom_components" / "ai_automation_suggester" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+suggestions = load_module("suggestions")
+
+
+def test_parse_structured_json_suggestion():
+    raw = """
+    {
+      "suggestions": [
+        {
+          "title": "Turn on hall light",
+          "description": "Turns on the hall light when motion is detected.",
+          "yaml": "alias: Hall motion light\\ntrigger: []\\naction: []",
+          "entities_used": ["binary_sensor.hall_motion", "light.hall"]
+        }
+      ]
+    }
+    """
+
+    parsed = suggestions.parse_suggestion_response(
+        raw,
+        provider="OpenAI",
+        model="gpt-5.5",
+        created_at=datetime(2026, 5, 3, 12, 0, 0),
+        entities_processed=["binary_sensor.hall_motion"],
+    )
+
+    assert parsed[0]["title"] == "Turn on hall light"
+    assert parsed[0]["yamlCode"].startswith("alias: Hall")
+    assert parsed[0]["provider"] == "OpenAI"
+
+
+def test_parse_fenced_yaml_fallback():
+    raw = """Use this automation.
+
+```yaml
+alias: Kitchen reminder
+trigger: []
+action: []
+```
+"""
+
+    parsed = suggestions.parse_suggestion_response(
+        raw,
+        provider="Anthropic",
+        model="claude-sonnet-4-6",
+        created_at=datetime(2026, 5, 3, 12, 0, 0),
+        entities_processed=["sensor.kitchen"],
+    )
+
+    assert parsed[0]["description"].startswith("Use this automation")
+    assert "Kitchen reminder" in parsed[0]["yamlCode"]
+
+
+def test_length_finish_reason_adds_warning():
+    parsed = suggestions.parse_suggestion_response(
+        "No YAML this time",
+        provider="OpenRouter",
+        model="openai/gpt-5.4-mini",
+        created_at=datetime(2026, 5, 3, 12, 0, 0),
+        entities_processed=[],
+        response_metadata={"finish_reason": "length"},
+    )
+
+    assert any("truncated" in warning for warning in parsed[0]["warnings"])


### PR DESCRIPTION
## Summary

- Adds model capability metadata and safer request shaping for current provider/model families.
- Adds structured suggestion parsing, persistent history storage, review services, and backed dashboard API endpoints.
- Refreshes docs, release notes, issue/PR templates, and test/lint CI scaffolding for the 1.5.0 foundation release.

## Testing

- [x] pytest tests
- [x] ruff check custom_components/ai_automation_suggester/model_catalog.py custom_components/ai_automation_suggester/suggestions.py custom_components/ai_automation_suggester/store.py custom_components/ai_automation_suggester/api.py tests
- [x] py_compile on integration modules
- [x] git diff --check

## Release Notes

- Release notes are included in docs/RELEASE_1.5.0.md.
- Publish the GitHub release/tag after this PR is merged into main so HACS can detect 1.5.0.