### PR TITLE
Fix malformed structured suggestion notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.5.1 - 2026-05-03
+
+### Fixed
+
+- Fixed persistent notifications showing raw malformed JSON-like provider output when models returned unescaped multiline YAML inside structured responses.
+- Added best-effort parsing for malformed structured suggestions so title, description, YAML, entities, confidence, and warnings can still be recovered.
+- Replaced raw JSON-like fallback notification bodies with a short parse-failure message.
+
 ## 1.5.0 - 2026-05-03
 
 ### Added

--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -13,5 +13,5 @@
     "pyyaml>=6.0",
     "voluptuous>=0.13.1"
   ],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/custom_components/ai_automation_suggester/suggestions.py
+++ b/custom_components/ai_automation_suggester/suggestions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import textwrap
 from datetime import datetime
 from typing import Any
 from uuid import uuid4
@@ -12,6 +13,7 @@ import yaml
 
 YAML_RE = re.compile(r"```(?:yaml|yml)\s*([\s\S]+?)\s*```", flags=re.IGNORECASE)
 JSON_RE = re.compile(r"```json\s*([\s\S]+?)\s*```", flags=re.IGNORECASE)
+STRING_FIELDS_AFTER_YAML = "entities_used|automation_ids_used|confidence|warnings"
 
 
 STRUCTURED_OUTPUT_INSTRUCTIONS = """
@@ -61,6 +63,87 @@ def _try_json_loads(raw_response: str) -> dict | list | None:
             except json.JSONDecodeError:
                 return None
     return None
+
+
+def _decode_jsonish_string(value: str) -> str:
+    """Decode a JSON string fragment when possible."""
+
+    try:
+        return str(json.loads(f'"{value}"'))
+    except json.JSONDecodeError:
+        return value.replace('\\"', '"').replace("\\n", "\n").strip()
+
+
+def _extract_string_field(segment: str, field: str) -> str | None:
+    match = re.search(rf'"{re.escape(field)}"\s*:\s*"((?:\\.|[^"\\])*)"', segment)
+    return _decode_jsonish_string(match.group(1)).strip() if match else None
+
+
+def _extract_array_field(segment: str, field: str) -> list:
+    match = re.search(rf'"{re.escape(field)}"\s*:\s*(\[[\s\S]*?\])', segment)
+    if not match:
+        return []
+    try:
+        value = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return []
+    return value if isinstance(value, list) else []
+
+
+def _extract_number_field(segment: str, field: str) -> float | None:
+    match = re.search(rf'"{re.escape(field)}"\s*:\s*(-?\d+(?:\.\d+)?)', segment)
+    return float(match.group(1)) if match else None
+
+
+def _extract_yaml_field(segment: str) -> str | None:
+    malformed = re.search(
+        rf'"yaml"\s*:\s*""\s*\r?\n(?P<yaml>[\s\S]*?)\r?\n\s*""\s*,?\s*(?=\r?\n\s*"(?:{STRING_FIELDS_AFTER_YAML})"|\r?\n\s*\}})',
+        segment,
+    )
+    if malformed:
+        return textwrap.dedent(malformed.group("yaml")).strip() or None
+
+    valid = re.search(r'"yaml"\s*:\s*"((?:\\.|[^"\\])*)"', segment)
+    if valid:
+        return _decode_jsonish_string(valid.group(1)).strip() or None
+    return None
+
+
+def _try_loose_structured_items(raw_response: str) -> list[dict[str, Any]]:
+    """Extract suggestions from malformed JSON-like provider responses."""
+
+    if '"suggestions"' not in raw_response and '"title"' not in raw_response:
+        return []
+
+    title_matches = list(re.finditer(r'"title"\s*:', raw_response))
+    items: list[dict[str, Any]] = []
+    for index, match in enumerate(title_matches):
+        start = raw_response.rfind("{", 0, match.start())
+        if start == -1:
+            start = match.start()
+        end = title_matches[index + 1].start() if index + 1 < len(title_matches) else len(raw_response)
+        segment = raw_response[start:end]
+
+        title = _extract_string_field(segment, "title")
+        description = _extract_string_field(segment, "description")
+        yaml_code = _extract_yaml_field(segment)
+        if not any((title, description, yaml_code)):
+            continue
+
+        item: dict[str, Any] = {
+            "title": title,
+            "description": description,
+            "yaml": yaml_code,
+            "entities_used": _extract_array_field(segment, "entities_used"),
+            "automation_ids_used": _extract_array_field(segment, "automation_ids_used"),
+            "warnings": _extract_array_field(segment, "warnings"),
+        }
+        confidence = _extract_number_field(segment, "confidence")
+        if confidence is not None:
+            item["confidence"] = confidence
+        items.append(item)
+
+    return items
 
 
 def _validate_yaml(yaml_code: str | None) -> list[str]:
@@ -163,10 +246,46 @@ def parse_suggestion_response(
         ]
         if suggestions:
             return suggestions
+    elif isinstance(structured, list):
+        suggestions = [
+            _normalise_suggestion(
+                item if isinstance(item, dict) else {"description": str(item)},
+                provider=provider,
+                model=model,
+                created_at=created_at,
+                entities_processed=entities_processed,
+                inherited_warnings=inherited,
+                response_metadata=metadata,
+            )
+            for item in structured
+        ]
+        if suggestions:
+            return suggestions
+
+    loose_items = _try_loose_structured_items(raw_response)
+    if loose_items:
+        loose_warnings = [*inherited, "The provider returned malformed JSON; suggestions were parsed best-effort."]
+        return [
+            _normalise_suggestion(
+                item,
+                provider=provider,
+                model=model,
+                created_at=created_at,
+                entities_processed=entities_processed,
+                inherited_warnings=loose_warnings,
+                response_metadata=metadata,
+            )
+            for item in loose_items
+        ]
 
     yaml_match = YAML_RE.search(raw_response)
     yaml_code = yaml_match.group(1).strip() if yaml_match else None
-    description = YAML_RE.sub("", raw_response).strip() if yaml_match else raw_response.strip()
+    if yaml_match:
+        description = YAML_RE.sub("", raw_response).strip()
+    elif raw_response.lstrip().startswith(("{", "[")) or '"suggestions"' in raw_response:
+        description = "The provider returned structured output that could not be parsed. Try regenerating with a lower entity limit or a newer model."
+    else:
+        description = raw_response.strip()
     return [
         _normalise_suggestion(
             {

--- a/docs/RELEASE_1.5.1.md
+++ b/docs/RELEASE_1.5.1.md
@@ -1,0 +1,13 @@
+# AI Automation Suggester 1.5.1
+
+This patch release fixes persistent notifications when an AI provider returns malformed structured output.
+
+## Fixed
+
+- Recovers suggestions from JSON-like responses where the provider emits multiline YAML outside a valid JSON string.
+- Prevents raw malformed JSON payloads from being shown as the persistent notification body.
+- Adds regression tests for malformed Mistral-style structured responses.
+
+## Notes
+
+If a provider reports a `length` or token-limit finish reason, the integration still shows a truncation warning. Lower the entity limit or output a smaller number of suggestions if the response is cut off.

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -81,3 +81,67 @@ def test_length_finish_reason_adds_warning():
     )
 
     assert any("truncated" in warning for warning in parsed[0]["warnings"])
+
+
+def test_parse_malformed_json_yaml_blocks_from_provider():
+        raw = '''
+{
+    "suggestions": [
+        {
+            "title": "Laundry Drying Alerts Based on Weather",
+            "description": "Notify when the laundry drying index is favorable.",
+            "yaml": ""
+                alias: "Notify when laundry drying conditions are optimal"
+                trigger:
+                    - platform: numeric_state
+                        entity_id: sensor.laundry_drying_index
+                        above: 70
+                action:
+                    - service: notify.notify
+                        data:
+                            message: "Optimal laundry drying conditions now!"
+            "",
+            "entities_used": [
+                "sensor.laundry_drying_index",
+                "sun.sun"
+            ],
+            "automation_ids_used": [],
+            "confidence": 0.6,
+            "warnings": [
+                "Adjust the threshold based on your local climate."
+            ]
+        }
+    ]
+}
+'''
+
+        parsed = suggestions.parse_suggestion_response(
+                raw,
+                provider="Mistral AI",
+                model="mistral-medium",
+                created_at=datetime(2026, 5, 3, 12, 0, 0),
+                entities_processed=["sensor.laundry_drying_index"],
+                response_metadata={"finish_reason": "length"},
+        )
+
+        assert parsed[0]["title"] == "Laundry Drying Alerts Based on Weather"
+        assert parsed[0]["description"] == "Notify when the laundry drying index is favorable."
+        assert parsed[0]["yamlCode"].startswith("alias:")
+        assert "sensor.laundry_drying_index" in parsed[0]["entities_used"]
+        assert not any(warning == "No automation YAML was returned." for warning in parsed[0]["warnings"])
+        assert any("malformed JSON" in warning for warning in parsed[0]["warnings"])
+
+
+def test_unparseable_structured_payload_does_not_become_notification_body():
+        raw = '{"suggestions": [ this is not recoverable ]}'
+
+        parsed = suggestions.parse_suggestion_response(
+                raw,
+                provider="Mistral AI",
+                model="mistral-medium",
+                created_at=datetime(2026, 5, 3, 12, 0, 0),
+                entities_processed=[],
+        )
+
+        assert not parsed[0]["description"].startswith("{")
+        assert "could not be parsed" in parsed[0]["description"]


### PR DESCRIPTION
## Summary

- Recovers suggestions from malformed JSON-like provider responses that contain raw multiline YAML.
- Prevents raw structured provider payloads from being shown as persistent notification bodies.
- Bumps the integration to 1.5.1 with patch release notes.

## Testing

- [x] pytest tests
- [x] ruff check custom_components/ai_automation_suggester/model_catalog.py custom_components/ai_automation_suggester/suggestions.py custom_components/ai_automation_suggester/store.py custom_components/ai_automation_suggester/api.py tests
- [x] py_compile on integration modules
- [x] git diff --check