### PR TITLE
Polish parser recovery notification warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.5.2 - 2026-05-03
+
+### Changed
+
+- Reworded parser-repair and truncated-response warnings in persistent notifications so they are user-facing instead of implementation-oriented.
+
+### Fixed
+
+- Normalized malformed-response parser regression test formatting.
+
 ## 1.5.1 - 2026-05-03
 
 ### Fixed

--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -13,5 +13,5 @@
     "pyyaml>=6.0",
     "voluptuous>=0.13.1"
   ],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/custom_components/ai_automation_suggester/suggestions.py
+++ b/custom_components/ai_automation_suggester/suggestions.py
@@ -14,6 +14,7 @@ import yaml
 YAML_RE = re.compile(r"```(?:yaml|yml)\s*([\s\S]+?)\s*```", flags=re.IGNORECASE)
 JSON_RE = re.compile(r"```json\s*([\s\S]+?)\s*```", flags=re.IGNORECASE)
 STRING_FIELDS_AFTER_YAML = "entities_used|automation_ids_used|confidence|warnings"
+PARSE_REPAIR_WARNING = "The provider returned malformed JSON; suggestions were parsed best-effort."
 
 
 STRUCTURED_OUTPUT_INSTRUCTIONS = """
@@ -264,7 +265,7 @@ def parse_suggestion_response(
 
     loose_items = _try_loose_structured_items(raw_response)
     if loose_items:
-        loose_warnings = [*inherited, "The provider returned malformed JSON; suggestions were parsed best-effort."]
+        loose_warnings = [*inherited, PARSE_REPAIR_WARNING]
         return [
             _normalise_suggestion(
                 item,
@@ -315,5 +316,16 @@ def format_suggestion_notification(suggestion: dict[str, Any]) -> str:
         parts.append("```yaml\n" + str(yaml_code).strip() + "\n```")
     warnings = suggestion.get("warnings") or []
     if warnings:
-        parts.append("Warnings:\n" + "\n".join(f"- {warning}" for warning in warnings))
+        parts.append("Warnings:\n" + "\n".join(f"- {_format_notification_warning(warning)}" for warning in warnings))
     return "\n\n".join(parts)
+
+
+def _format_notification_warning(warning: Any) -> str:
+    """Return a concise user-facing warning for notifications."""
+
+    text = str(warning)
+    if text == PARSE_REPAIR_WARNING:
+        return "Provider response needed formatting repair before display. Review the YAML before using it."
+    if text == "The provider reported a length finish reason; the suggestion may be truncated.":
+        return "The AI response may have been cut off. Review the YAML before using it."
+    return text

--- a/docs/RELEASE_1.5.2.md
+++ b/docs/RELEASE_1.5.2.md
@@ -1,0 +1,12 @@
+# AI Automation Suggester 1.5.2
+
+This patch release polishes warning text shown in persistent notifications after best-effort parser recovery.
+
+## Changed
+
+- Rewords the parser repair warning from technical JSON terminology to: "Provider response needed formatting repair before display. Review the YAML before using it."
+- Rewords token-limit truncation warnings to make clear the YAML should be reviewed before use.
+
+## Notes
+
+The integration still keeps the technical parser warning in stored suggestion attributes for troubleshooting. Persistent notifications now use friendlier wording.

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -84,7 +84,7 @@ def test_length_finish_reason_adds_warning():
 
 
 def test_parse_malformed_json_yaml_blocks_from_provider():
-        raw = '''
+    raw = '''
 {
     "suggestions": [
         {
@@ -115,33 +115,46 @@ def test_parse_malformed_json_yaml_blocks_from_provider():
 }
 '''
 
-        parsed = suggestions.parse_suggestion_response(
-                raw,
-                provider="Mistral AI",
-                model="mistral-medium",
-                created_at=datetime(2026, 5, 3, 12, 0, 0),
-                entities_processed=["sensor.laundry_drying_index"],
-                response_metadata={"finish_reason": "length"},
-        )
+    parsed = suggestions.parse_suggestion_response(
+        raw,
+        provider="Mistral AI",
+        model="mistral-medium",
+        created_at=datetime(2026, 5, 3, 12, 0, 0),
+        entities_processed=["sensor.laundry_drying_index"],
+        response_metadata={"finish_reason": "length"},
+    )
 
-        assert parsed[0]["title"] == "Laundry Drying Alerts Based on Weather"
-        assert parsed[0]["description"] == "Notify when the laundry drying index is favorable."
-        assert parsed[0]["yamlCode"].startswith("alias:")
-        assert "sensor.laundry_drying_index" in parsed[0]["entities_used"]
-        assert not any(warning == "No automation YAML was returned." for warning in parsed[0]["warnings"])
-        assert any("malformed JSON" in warning for warning in parsed[0]["warnings"])
+    assert parsed[0]["title"] == "Laundry Drying Alerts Based on Weather"
+    assert parsed[0]["description"] == "Notify when the laundry drying index is favorable."
+    assert parsed[0]["yamlCode"].startswith("alias:")
+    assert "sensor.laundry_drying_index" in parsed[0]["entities_used"]
+    assert not any(warning == "No automation YAML was returned." for warning in parsed[0]["warnings"])
+    assert any("malformed JSON" in warning for warning in parsed[0]["warnings"])
+
+
+def test_notification_formats_parser_repair_warning_for_users():
+    message = suggestions.format_suggestion_notification(
+        {
+            "title": "Recovered suggestion",
+            "description": "A recovered suggestion.",
+            "warnings": [suggestions.PARSE_REPAIR_WARNING],
+        }
+    )
+
+    assert "malformed JSON" not in message
+    assert "needed formatting repair" in message
 
 
 def test_unparseable_structured_payload_does_not_become_notification_body():
-        raw = '{"suggestions": [ this is not recoverable ]}'
+    raw = '{"suggestions": [ this is not recoverable ]}'
 
-        parsed = suggestions.parse_suggestion_response(
-                raw,
-                provider="Mistral AI",
-                model="mistral-medium",
-                created_at=datetime(2026, 5, 3, 12, 0, 0),
-                entities_processed=[],
-        )
+    parsed = suggestions.parse_suggestion_response(
+        raw,
+        provider="Mistral AI",
+        model="mistral-medium",
+        created_at=datetime(2026, 5, 3, 12, 0, 0),
+        entities_processed=[],
+    )
 
-        assert not parsed[0]["description"].startswith("{")
-        assert "could not be parsed" in parsed[0]["description"]
+    assert not parsed[0]["description"].startswith("{")
+    assert "could not be parsed" in parsed[0]["description"]


### PR DESCRIPTION
## Summary

- Rewords parser-recovery warnings in persistent notifications so they are user-facing rather than implementation-oriented.
- Keeps technical parser details in stored suggestion attributes for troubleshooting.
- Bumps the integration to 1.5.2 with patch release notes.

## Testing

- [x] pytest tests
- [x] ruff check selected helper modules and tests
- [x] py_compile on integration modules
- [x] git diff --check