### PR TITLE
Improve localization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.5.5 - 2026-05-03
+
+### Added
+
+- Added Czech translations from the community contribution, updated for the current setup/options schema.
+- Added prompt localization so generated suggestion titles, descriptions, and warnings follow the configured Home Assistant language when it is not English.
+
+### Fixed
+
+- Completed missing Italian service and option translation keys, including newer exclusion, history, timeout, OpenAI reasoning, and Ollama/Open WebUI fields.
+- Fixed the reported spacing and capitalization typos in the contributed Czech wording.
+
 ## 1.5.4 - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ The `entity_limit` parameter is crucial for managing prompt size, particularly w
 
 The `custom_prompt` parameter allows you to be very specific about the type of suggestions you want for a particular run. Combine it with domain filtering for highly targeted results (e.g., `domains: ['climate'], custom_prompt: "Suggest automations to optimize heating/cooling based on occupancy and weather."`).
 
+When Home Assistant is configured to a supported non-English language, generated suggestion titles, descriptions, and warnings are prompted in that language. YAML, entity IDs, service names, and code identifiers remain unchanged. Use the persistent custom system prompt or `custom_prompt` if you want to force a different output language for a specific provider or run.
+
 ---
 
 ## Implementing Automations

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import *
 from .endpoint_utils import bearer_auth_headers, ollama_api_candidates, ollama_base_url, openai_chat_endpoint
+from .language_utils import suggestion_language_instruction
 from .model_catalog import (
     chat_token_parameter,
     compatibility_warnings,
@@ -413,10 +414,13 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         autom_codes: list[str] = []
         if self.automation_read_file:
             autom_codes = await self._read_automations_file_method(max_autom)
+        language_instruction = suggestion_language_instruction(getattr(self.hass.config, "language", None))
+        language_block = f"{language_instruction}\n\n" if language_instruction else ""
 
         return (
             f"{self.SYSTEM_PROMPT}\n\n"
             f"{STRUCTURED_OUTPUT_INSTRUCTIONS}\n\n"
+            f"{language_block}"
             f"Entities in your Home Assistant (sampled):\n{''.join(ent_sections)}\n"
             "Existing Automations Overview:\n"
             f"{''.join(autom_sections) if autom_sections else 'None found.'}\n\n"

--- a/custom_components/ai_automation_suggester/language_utils.py
+++ b/custom_components/ai_automation_suggester/language_utils.py
@@ -1,0 +1,38 @@
+"""Language helpers for suggestion prompt localization."""
+
+LANGUAGE_NAMES = {
+    "ca": "Catalan",
+    "cs": "Czech",
+    "de": "German",
+    "en": "English",
+    "es": "Spanish",
+    "it": "Italian",
+    "nl": "Dutch",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "tr": "Turkish",
+    "zh": "Chinese",
+}
+
+
+def language_name(language_code: str | None) -> str | None:
+    """Return a friendly language name from a Home Assistant language code."""
+
+    normalized = str(language_code or "").strip().replace("_", "-").lower()
+    if not normalized:
+        return None
+    base_code = normalized.split("-", 1)[0]
+    return LANGUAGE_NAMES.get(base_code, normalized)
+
+
+def suggestion_language_instruction(language_code: str | None) -> str:
+    """Build an instruction that asks providers to localize suggestion text."""
+
+    name = language_name(language_code)
+    if not name or name == "English":
+        return ""
+    return (
+        f"Home Assistant configured language: {name}. "
+        f"Write suggestion titles, descriptions, and warnings in {name}. "
+        "Keep YAML, entity_ids, service names, and code identifiers unchanged."
+    )

--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -13,5 +13,5 @@
     "pyyaml>=6.0",
     "voluptuous>=0.13.1"
   ],
-  "version": "1.5.4"
+  "version": "1.5.5"
 }

--- a/custom_components/ai_automation_suggester/translations/cs.json
+++ b/custom_components/ai_automation_suggester/translations/cs.json
@@ -1,0 +1,293 @@
+{
+  "title": "AI Návrhář automatizací",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Vyberte poskytovatele AI",
+        "data": {
+          "provider": "Poskytovatel AI"
+        }
+      },
+      "openai": {
+        "title": "Nakonfigurovat OpenAI",
+        "data": {
+          "openai_api_key": "OpenAI API klíč",
+          "openai_model": "Model OpenAI",
+          "openai_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "anthropic": {
+        "title": "Nakonfigurovat Anthropic",
+        "data": {
+          "anthropic_api_key": "Anthropic API klíč",
+          "anthropic_model": "Model Anthropic",
+          "anthropic_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "google": {
+        "title": "Nakonfigurovat Google",
+        "data": {
+          "google_api_key": "Google API klíč",
+          "google_model": "Model Google",
+          "google_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "groq": {
+        "title": "Nakonfigurovat Groq",
+        "data": {
+          "groq_api_key": "Groq API klíč",
+          "groq_model": "Model Groq",
+          "groq_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "localai": {
+        "title": "Nakonfigurovat LocalAI",
+        "data": {
+          "localai_ip": "IP adresa LocalAI",
+          "localai_port": "Port LocalAI",
+          "localai_https": "Použít HTTPS pro LocalAI",
+          "localai_model": "Model LocalAI",
+          "localai_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "ollama": {
+        "title": "Nakonfigurovat Ollama",
+        "data": {
+          "ollama_base_url": "Základní URL Ollama/Open WebUI",
+          "ollama_api_key": "API klíč Ollama/Open WebUI (volitelné)",
+          "ollama_ip": "IP adresa Ollama",
+          "ollama_port": "Port Ollama",
+          "ollama_https": "Použít HTTPS pro Ollama",
+          "ollama_model": "Model Ollama",
+          "ollama_temperature": "Teplota",
+          "ollama_disable_think": "Zakázat režim přemýšlení (Ollama)",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "custom_openai": {
+        "title": "Nakonfigurovat vlastní OpenAI",
+        "data": {
+          "custom_openai_endpoint": "Koncový bod vlastního OpenAI",
+          "custom_openai_api_key": "API klíč vlastního OpenAI (volitelné)",
+          "custom_openai_model": "Model vlastního OpenAI",
+          "custom_openai_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "mistral": {
+        "title": "Nakonfigurovat Mistral AI",
+        "data": {
+          "mistral_api_key": "Mistral API klíč",
+          "mistral_model": "Model Mistral",
+          "mistral_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "perplexity": {
+        "title": "Nakonfigurovat Perplexity AI",
+        "data": {
+          "perplexity_api_key": "Perplexity API klíč",
+          "perplexity_model": "Model Perplexity",
+          "perplexity_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "openrouter": {
+        "title": "Nakonfigurovat OpenRouter",
+        "data": {
+          "openrouter_api_key": "OpenRouter API klíč",
+          "openrouter_model": "Model OpenRouter",
+          "openrouter_reasoning_max_tokens": "Maximální počet tokenů pro uvažování OpenRouter",
+          "openrouter_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "openai_azure": {
+        "title": "Nakonfigurovat Azure OpenAI",
+        "data": {
+          "openai_azure_api_key": "Azure OpenAI API klíč",
+          "openai_azure_deployment_id": "ID nasazení Azure",
+          "openai_azure_endpoint": "Koncový bod Azure",
+          "openai_azure_api_version": "Verze Azure API",
+          "openai_azure_temperature": "Teplota",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      },
+      "generic_openai": {
+        "title": "Nakonfigurovat obecné OpenAI",
+        "data": {
+          "generic_openai_api_endpoint": "Úplná URL adresa API obecného OpenAI (musí končit na 'completions')",
+          "generic_openai_api_key": "API klíč obecného OpenAI (volitelné)",
+          "generic_openai_model": "Model obecného OpenAI",
+          "generic_openai_temperature": "Teplota",
+          "generic_openai_validation_endpoint": "Ověřovací URL (musí končit na 'models')",
+          "generic_openai_enable_validation": "Povolit ověřování",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů"
+        }
+      }
+    },
+    "error": {
+      "api_error": "Ověření API se nezdařilo: {error_message}",
+      "cannot_connect": "Nepodařilo se připojit. Zkontrolujte nastavení a síť.",
+      "unknown": "Došlo k neznámé chybě. Podrobnosti najdete v logu."
+    },
+    "abort": {
+      "already_configured": "Tento poskytovatel AI je již nakonfigurován. Můžete jej upravit na stránce integrací."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Nastavení AI Návrháře automatizací",
+        "data": {
+          "openai_api_key": "OpenAI API klíč",
+          "openai_model": "Model OpenAI",
+          "openai_temperature": "Teplota (OpenAI)",
+          "anthropic_api_key": "Anthropic API klíč",
+          "anthropic_model": "Model Anthropic",
+          "anthropic_temperature": "Teplota (Anthropic)",
+          "google_api_key": "Google API klíč",
+          "google_model": "Model Google",
+          "google_temperature": "Teplota (Google)",
+          "groq_api_key": "Groq API klíč",
+          "groq_model": "Model Groq",
+          "groq_temperature": "Teplota (Groq)",
+          "localai_ip": "IP adresa LocalAI",
+          "localai_port": "Port LocalAI",
+          "localai_https": "Používat HTTPS pro LocalAI",
+          "localai_model": "Model LocalAI",
+          "localai_temperature": "Teplota (LocalAI)",
+          "ollama_base_url": "Základní URL Ollama/Open WebUI",
+          "ollama_api_key": "API klíč Ollama/Open WebUI (volitelné)",
+          "ollama_ip": "IP adresa Ollama",
+          "ollama_port": "Port Ollama",
+          "ollama_https": "Používat HTTPS pro Ollama",
+          "ollama_model": "Model Ollama",
+          "ollama_temperature": "Teplota (Ollama)",
+          "ollama_disable_think": "Zakázat režim přemýšlení (Ollama)",
+          "custom_openai_endpoint": "Koncový bod vlastního OpenAI",
+          "custom_openai_api_key": "API klíč vlastního OpenAI",
+          "custom_openai_model": "Model vlastního OpenAI",
+          "custom_openai_temperature": "Teplota (vlastní OpenAI)",
+          "mistral_api_key": "Mistral API klíč",
+          "mistral_model": "Model Mistral",
+          "mistral_temperature": "Teplota (Mistral AI)",
+          "perplexity_api_key": "Perplexity API klíč",
+          "perplexity_model": "Model Perplexity",
+          "perplexity_temperature": "Teplota (Perplexity AI)",
+          "openrouter_api_key": "OpenRouter API klíč",
+          "openrouter_model": "Model OpenRouter",
+          "openrouter_reasoning_max_tokens": "Maximální počet tokenů pro uvažování OpenRouter",
+          "openrouter_temperature": "Teplota (OpenRouter)",
+          "openai_azure_api_key": "Azure OpenAI API klíč",
+          "openai_azure_deployment_id": "ID nasazení Azure",
+          "openai_azure_endpoint": "Koncový bod Azure",
+          "openai_azure_api_version": "Verze Azure API",
+          "openai_azure_temperature": "Teplota (Azure OpenAI)",
+          "generic_openai_api_endpoint": "Úplná URL adresa API obecného OpenAI (musí končit na 'completions')",
+          "generic_openai_api_key": "API klíč obecného OpenAI",
+          "generic_openai_model": "Model obecného OpenAI",
+          "generic_openai_temperature": "Teplota (obecné OpenAI)",
+          "generic_openai_validation_endpoint": "Ověřovací URL (obecné OpenAI, musí končit na 'models')",
+          "generic_openai_enable_validation": "Povolit ověřování (obecné OpenAI)",
+          "max_input_tokens": "Maximální počet vstupních tokenů",
+          "max_output_tokens": "Maximální počet výstupních tokenů",
+          "custom_system_prompt": "Trvalý vlastní systémový prompt",
+          "excluded_domains": "Vyloučené domény",
+          "excluded_entities": "Vyloučené entity",
+          "excluded_areas": "Vyloučené oblasti",
+          "history_retention": "Uchování historie návrhů",
+          "request_timeout": "Časový limit požadavku na poskytovatele",
+          "openai_reasoning_effort": "Úroveň uvažování OpenAI"
+        },
+        "description": "Upravte nastavení svých poskytovatelů AI. Použijí se pole relevantní pro nakonfigurovaného poskytovatele. Běžná nastavení, jako jsou limity tokenů, se konfigurují pro každého poskytovatele zvlášť."
+      }
+    },
+    "error": {
+      "invalid_input": "Jedna nebo více hodnot je neplatná."
+    }
+  },
+  "services": {
+    "generate_suggestions": {
+      "name": "Generovat návrhy",
+      "description": "Ručně spustit návrhy automatizací AI.",
+      "fields": {
+        "provider_config": {
+          "name": "Konfigurace poskytovatele",
+          "description": "Kterou konfiguraci poskytovatele použít (pokud jich máte více)?"
+        },
+        "custom_prompt": {
+          "name": "Vlastní prompt",
+          "description": "Volitelný vlastní prompt pro přepsání výchozího systémového promptu nebo směrování návrhů k určitým tématům."
+        },
+        "all_entities": {
+          "name": "Zohlednit všechny entity",
+          "description": "Pokud je zapnuto, zohlední všechny entity místo pouze nových entit."
+        },
+        "domains": {
+          "name": "Domény",
+          "description": "Seznam domén ke zohlednění. Pokud je prázdný, zohlední všechny domény."
+        },
+        "entity_limit": {
+          "name": "Limit entit",
+          "description": "Maximální počet entit ke zohlednění (náhodně vybrané)."
+        },
+        "automation_read_yaml": {
+          "name": "Číst soubor 'automations.yaml'",
+          "description": "Přečte a přidá YAML kód automatizací nalezených v souboru 'automations.yaml'. Tato akce použije mnoho vstupních tokenů, používejte ji opatrně a s modely s velkým kontextovým oknem (např. Gemini)."
+        },
+        "automation_limit": {
+          "name": "Limit automatizací",
+          "description": "Maximální počet automatizací k analýze (výchozí: 100)."
+        },
+        "exclude_domains": {
+          "name": "Vyloučit domény",
+          "description": "Domény, které se mají vyloučit z analýzy."
+        },
+        "exclude_entities": {
+          "name": "Vyloučit entity",
+          "description": "ID entit, které se mají vyloučit z analýzy."
+        },
+        "exclude_areas": {
+          "name": "Vyloučit oblasti",
+          "description": "Oblasti, které se mají vyloučit z analýzy."
+        }
+      }
+    },
+    "clear_history": {
+      "name": "Vymazat historii návrhů",
+      "description": "Vymazat všechny uložené návrhy automatizací AI."
+    },
+    "update_suggestion": {
+      "name": "Aktualizovat návrh",
+      "description": "Aktualizovat stav kontroly uloženého návrhu automatizace AI.",
+      "fields": {
+        "suggestion_id": {
+          "name": "ID návrhu",
+          "description": "ID návrhu, který se má aktualizovat."
+        },
+        "status": {
+          "name": "Stav",
+          "description": "Nový stav kontroly."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/ai_automation_suggester/translations/it.json
+++ b/custom_components/ai_automation_suggester/translations/it.json
@@ -63,6 +63,8 @@
       "ollama": {
         "title": "Configura Ollama",
         "data": {
+          "ollama_base_url": "URL base Ollama/Open WebUI",
+          "ollama_api_key": "Chiave API Ollama/Open WebUI (opzionale)",
           "ollama_ip": "Indirizzo IP Ollama",
           "ollama_port": "Porta Ollama",
           "ollama_https": "Usa HTTPS per Ollama",
@@ -172,6 +174,8 @@
           "localai_https": "Usa HTTPS per LocalAI",
           "localai_model": "Modello LocalAI",
           "localai_temperature": "Temperatura (LocalAI)",
+          "ollama_base_url": "URL base Ollama/Open WebUI",
+          "ollama_api_key": "Chiave API Ollama/Open WebUI (opzionale)",
           "ollama_ip": "Indirizzo IP Ollama",
           "ollama_port": "Porta Ollama",
           "ollama_https": "Usa HTTPS per Ollama",
@@ -204,7 +208,14 @@
           "generic_openai_validation_endpoint": "URL di validazione (OpenAI Generico, deve terminare con 'models')",
           "generic_openai_enable_validation": "Abilita Validazione (OpenAI Generico)",
           "max_input_tokens": "Numero massimo di token di input",
-          "max_output_tokens": "Numero massimo di token di output"
+          "max_output_tokens": "Numero massimo di token di output",
+          "custom_system_prompt": "Prompt di sistema personalizzato persistente",
+          "excluded_domains": "Domini esclusi",
+          "excluded_entities": "Entità escluse",
+          "excluded_areas": "Aree escluse",
+          "history_retention": "Conservazione cronologia suggerimenti",
+          "request_timeout": "Timeout richiesta provider",
+          "openai_reasoning_effort": "Intensità di ragionamento OpenAI"
         },
         "description": "Regola le impostazioni per i tuoi provider di IA. Verranno utilizzati i campi pertinenti al provider configurato. Le impostazioni comuni, come i limiti dei token, sono configurate per ciascun provider."
       }
@@ -245,6 +256,36 @@
         "automation_limit": {
           "name": "Limite Automazioni",
           "description": "Numero massimo di automazioni da analizzare (predefinito: 100)."
+        },
+        "exclude_domains": {
+          "name": "Escludi domini",
+          "description": "Domini da escludere dall'analisi."
+        },
+        "exclude_entities": {
+          "name": "Escludi entità",
+          "description": "ID entità da escludere dall'analisi."
+        },
+        "exclude_areas": {
+          "name": "Escludi aree",
+          "description": "Aree da escludere dall'analisi."
+        }
+      }
+    },
+    "clear_history": {
+      "name": "Cancella cronologia suggerimenti",
+      "description": "Cancella tutti i suggerimenti di automazione AI memorizzati."
+    },
+    "update_suggestion": {
+      "name": "Aggiorna suggerimento",
+      "description": "Aggiorna lo stato di revisione di un suggerimento di automazione AI memorizzato.",
+      "fields": {
+        "suggestion_id": {
+          "name": "ID suggerimento",
+          "description": "L'ID del suggerimento da aggiornare."
+        },
+        "status": {
+          "name": "Stato",
+          "description": "Il nuovo stato di revisione."
         }
       }
     }

--- a/docs/FEATURE_REQUEST_PLAN.md
+++ b/docs/FEATURE_REQUEST_PLAN.md
@@ -15,8 +15,7 @@ Targets: #116, #122, #123, #127, #132, #144, #145, #150, #153
 
 Targets: #133, #151
 
-- Audit translation loading for the existing Italian file and confirm Home Assistant displays localized strings correctly.
-- Add Czech translations once the submitted wording is reviewed.
+- Status: implemented in v1.5.5; awaiting reporter confirmation before closing any issue that needs a live Home Assistant retest.
 - Keep translation files structurally aligned when new setup/options keys are added.
 
 ## Phase 3: Provider Expansion

--- a/docs/RELEASE_1.5.5.md
+++ b/docs/RELEASE_1.5.5.md
@@ -1,0 +1,15 @@
+# AI Automation Suggester 1.5.5
+
+This patch improves localization for setup text and generated AI suggestions.
+
+## Highlights
+
+- Added Czech translations from the community contribution, updated for the current setup/options schema.
+- Fixed the reported spacing and capitalization typos in the contributed Czech wording.
+- Completed missing Italian labels for services, exclusion filters, history, timeout, OpenAI reasoning, and Ollama/Open WebUI fields.
+- Added a prompt instruction so generated suggestion titles, descriptions, and warnings follow the configured Home Assistant language when it is not English.
+
+## Notes
+
+- YAML, entity IDs, service names, and code identifiers are still kept unchanged in generated suggestions.
+- Users can still override or strengthen language preferences with the persistent custom system prompt or per-call custom prompt.

--- a/tests/test_language_utils.py
+++ b/tests/test_language_utils.py
@@ -1,0 +1,39 @@
+"""Tests for suggestion prompt localization helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module(name: str):
+    path = Path(__file__).resolve().parents[1] / "custom_components" / "ai_automation_suggester" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+language_utils = load_module("language_utils")
+
+
+def test_language_name_normalizes_home_assistant_locale_codes():
+    assert language_utils.language_name("it") == "Italian"
+    assert language_utils.language_name("pt_BR") == "Portuguese"
+    assert language_utils.language_name("cs-CZ") == "Czech"
+
+
+def test_suggestion_language_instruction_skips_english_and_empty_values():
+    assert language_utils.suggestion_language_instruction(None) == ""
+    assert language_utils.suggestion_language_instruction("en") == ""
+
+
+def test_suggestion_language_instruction_preserves_yaml_identifiers():
+    instruction = language_utils.suggestion_language_instruction("it")
+
+    assert "Italian" in instruction
+    assert "Keep YAML" in instruction
+    assert "entity_ids" in instruction


### PR DESCRIPTION
## Summary
- add Czech translations from the community contribution, updated for the current schema
- complete missing Italian translation keys for newer options and services
- prompt generated suggestion text in the configured Home Assistant language when it is not English
- bump the integration to v1.5.5 and add release notes

## Verification
- c:/Users/graham/Documents/GitHub/ai_automation_suggester/.venv/Scripts/python.exe -B -m pytest -q tests
- c:/Users/graham/Documents/GitHub/ai_automation_suggester/.venv/Scripts/python.exe -B -m ruff check custom_components/ai_automation_suggester/language_utils.py tests/test_language_utils.py tests/test_endpoint_utils.py
- JSON parse check for custom_components/ai_automation_suggester/**/*.json
- Italian/Czech translation key coverage compared against en.json
- git diff --check