### PR TITLE
Fix Gemini response schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.6 - 2026-05-03
+
+### Fixed
+
+- Fixed Gemini 2.5 Flash requests failing with `additionalProperties` JSON schema validation errors by sending a Google-compatible response schema.
+
 ## 1.5.5 - 2026-05-03
 
 ### Added

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -30,6 +30,7 @@ from .language_utils import suggestion_language_instruction
 from .model_catalog import (
     chat_token_parameter,
     compatibility_warnings,
+    google_json_schema_response_format,
     json_schema_response_format,
     model_uses_responses_api,
     should_send_temperature,
@@ -711,7 +712,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         }
         if supports_json_schema("Google", model):
             generation_config["responseMimeType"] = "application/json"
-            generation_config["responseSchema"] = json_schema_response_format()["json_schema"]["schema"]
+            generation_config["responseSchema"] = google_json_schema_response_format()["json_schema"]["schema"]
         body = {"contents": [{"parts": [{"text": self._trim_prompt(prompt)}]}], "generationConfig": generation_config}
         endpoint = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
         response = await self._post_json(endpoint, body=body, provider_label="Google")

--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -13,5 +13,5 @@
     "pyyaml>=6.0",
     "voluptuous>=0.13.1"
   ],
-  "version": "1.5.5"
+  "version": "1.5.6"
 }

--- a/custom_components/ai_automation_suggester/model_catalog.py
+++ b/custom_components/ai_automation_suggester/model_catalog.py
@@ -444,6 +444,37 @@ def json_schema_response_format() -> dict:
     }
 
 
+def _strip_schema_keys(value, unsupported_keys: set[str]):
+    """Return a copy of a schema value without unsupported keys."""
+
+    if isinstance(value, dict):
+        return {
+            key: _strip_schema_keys(schema_value, unsupported_keys)
+            for key, schema_value in value.items()
+            if key not in unsupported_keys
+        }
+    if isinstance(value, list):
+        return [_strip_schema_keys(item, unsupported_keys) for item in value]
+    return value
+
+
+def google_json_schema_response_format() -> dict:
+    """Return a Google Gemini-compatible JSON schema response format."""
+
+    response_format = json_schema_response_format()
+    return {
+        "type": response_format["type"],
+        "json_schema": {
+            "name": response_format["json_schema"]["name"],
+            "strict": response_format["json_schema"]["strict"],
+            "schema": _strip_schema_keys(
+                response_format["json_schema"]["schema"],
+                {"additionalProperties"},
+            ),
+        },
+    }
+
+
 def compatibility_warnings(provider: str, model: str | None) -> list[str]:
     """Return user-facing warnings for the selected provider/model."""
 

--- a/docs/RELEASE_1.5.6.md
+++ b/docs/RELEASE_1.5.6.md
@@ -1,0 +1,12 @@
+# AI Automation Suggester 1.5.6
+
+This patch fixes Gemini 2.5 Flash structured-output requests.
+
+## Highlights
+
+- Sends a Google Gemini-compatible response schema that omits JSON Schema keywords rejected by the Gemini API.
+- Preserves the fuller JSON schema for OpenAI-compatible providers that accept it.
+
+## Fixed
+
+- Resolves Gemini API `400 INVALID_ARGUMENT` errors mentioning unsupported `additionalProperties` fields in `generation_config.response_schema`.

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -34,3 +34,22 @@ def test_unknown_local_model_is_allowed_as_custom():
     capabilities = model_catalog.get_model_capabilities("Ollama", "my-local-model")
     assert capabilities.model == "my-local-model"
     assert capabilities.status == model_catalog.STATUS_CUSTOM
+
+
+def test_google_json_schema_strips_additional_properties():
+    schema = model_catalog.google_json_schema_response_format()["json_schema"]["schema"]
+
+    def contains_key(value, target_key: str) -> bool:
+        if isinstance(value, dict):
+            return target_key in value or any(contains_key(item, target_key) for item in value.values())
+        if isinstance(value, list):
+            return any(contains_key(item, target_key) for item in value)
+        return False
+
+    assert not contains_key(schema, "additionalProperties")
+
+
+def test_openai_json_schema_keeps_additional_properties():
+    schema = model_catalog.json_schema_response_format()["json_schema"]["schema"]
+
+    assert "additionalProperties" in schema


### PR DESCRIPTION
## Summary
- add a Google/Gemini-compatible JSON schema formatter that removes unsupported `additionalProperties` keys
- route Google requests through the sanitized schema while preserving the full schema for OpenAI-compatible providers
- bump the integration to v1.5.6 and add release notes

## Verification
- c:/Users/graham/Documents/GitHub/ai_automation_suggester/.venv/Scripts/python.exe -B -m pytest -q tests/test_model_catalog.py
- c:/Users/graham/Documents/GitHub/ai_automation_suggester/.venv/Scripts/python.exe -B -m pytest -q tests
- c:/Users/graham/Documents/GitHub/ai_automation_suggester/.venv/Scripts/python.exe -B -m ruff check custom_components/ai_automation_suggester/model_catalog.py tests/test_model_catalog.py
- c:/Users/graham/Documents/GitHub/ai_automation_suggester/.venv/Scripts/python.exe -B -c "import json, pathlib; [json.load(path.open(encoding='utf-8')) for path in pathlib.Path('custom_components/ai_automation_suggester').glob('**/*.json')]; print('json ok')"
- py_compile for integration Python modules
- git diff --check