### PR TITLE
feat: add LiteLLM as AI provider for 100+ LLM backends

### DIFF
--- a/custom_components/ai_automation_suggester/config_flow.py
+++ b/custom_components/ai_automation_suggester/config_flow.py
@@ -181,6 +181,7 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "OpenRouter": self.async_step_openrouter,
                 "OpenAI Azure": self.async_step_openai_azure,
                 "Generic OpenAI": self.async_step_generic_openai,
+                "LiteLLM": self.async_step_litellm,
             }[self.provider]()
 
         return self.async_show_form(
@@ -194,6 +195,7 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             "Generic OpenAI",
                             "Google",
                             "Groq",
+                            "LiteLLM",
                             "LocalAI",
                             "Mistral AI",
                             "Ollama",
@@ -538,6 +540,29 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input,
         )
 
+    async def async_step_litellm(self, user_input=None):
+        """Handle the LiteLLM configuration."""
+        async def _v(ui):
+            if not ui.get(CONF_LITELLM_MODEL):
+                return "Model is required (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)"
+
+        schema = {
+            vol.Required(CONF_LITELLM_MODEL, default=DEFAULT_MODELS["LiteLLM"]): str,
+            vol.Optional(CONF_LITELLM_API_KEY, default=""): TextSelector(TextSelectorConfig(type="password")),
+            vol.Optional(CONF_LITELLM_API_BASE, default=""): str,
+            vol.Optional(CONF_LITELLM_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0)),
+        }
+        self._add_token_fields(schema)
+        return await self._provider_form(
+            "litellm",
+            vol.Schema(schema),
+            _v,
+            "AI Automation Suggester (LiteLLM)",
+            {},
+            {},
+            user_input,
+        )
+
     # ───────── Options flow (edit after setup) ─────────
     @staticmethod
     @callback
@@ -654,5 +679,10 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[vol.Optional(CONF_GENERIC_OPENAI_TEMPERATURE, default=self._get_option(CONF_GENERIC_OPENAI_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
             schema[vol.Optional(CONF_GENERIC_OPENAI_VALIDATION_ENDPOINT, default=self._get_option(CONF_GENERIC_OPENAI_VALIDATION_ENDPOINT, ""))] = str
             schema[vol.Optional(CONF_GENERIC_OPENAI_ENABLE_VALIDATION, default=self._get_option(CONF_GENERIC_OPENAI_ENABLE_VALIDATION, False))] = bool
+        elif provider == "LiteLLM":
+            schema[vol.Optional(CONF_LITELLM_API_KEY, default=self._get_option(CONF_LITELLM_API_KEY, ""))] = TextSelector(TextSelectorConfig(type="password"))
+            schema[vol.Optional(CONF_LITELLM_MODEL, default=self._get_option(CONF_LITELLM_MODEL, DEFAULT_MODELS["LiteLLM"]))] = str
+            schema[vol.Optional(CONF_LITELLM_API_BASE, default=self._get_option(CONF_LITELLM_API_BASE, ""))] = str
+            schema[vol.Optional(CONF_LITELLM_TEMPERATURE, default=self._get_option(CONF_LITELLM_TEMPERATURE, DEFAULT_TEMPERATURE))] = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=2.0))
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/custom_components/ai_automation_suggester/const.py
+++ b/custom_components/ai_automation_suggester/const.py
@@ -124,6 +124,12 @@ CONF_GENERIC_OPENAI_TEMPERATURE = "generic_openai_temperature"
 CONF_GENERIC_OPENAI_VALIDATION_ENDPOINT = "generic_openai_validation_endpoint"
 CONF_GENERIC_OPENAI_ENABLE_VALIDATION = "generic_openai_enable_validation"
 
+# LiteLLM
+CONF_LITELLM_API_KEY = "litellm_api_key"
+CONF_LITELLM_MODEL = "litellm_model"
+CONF_LITELLM_TEMPERATURE = "litellm_temperature"
+CONF_LITELLM_API_BASE = "litellm_api_base"
+
 # ─────────────────────────────────────────────────────────────
 # Model defaults per provider
 # ─────────────────────────────────────────────────────────────
@@ -140,6 +146,7 @@ DEFAULT_MODELS = {
     "Perplexity AI": "sonar",
     "OpenRouter": "openai/gpt-5.4-mini",
     "Generic OpenAI": "gpt-4o-mini",
+    "LiteLLM": "openai/gpt-4o-mini",
 }
 
 # ─────────────────────────────────────────────────────────────

--- a/custom_components/ai_automation_suggester/coordinator.py
+++ b/custom_components/ai_automation_suggester/coordinator.py
@@ -159,6 +159,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             "OpenRouter": CONF_OPENROUTER_MODEL,
             "OpenAI Azure": CONF_OPENAI_AZURE_DEPLOYMENT_ID,
             "Generic OpenAI": CONF_GENERIC_OPENAI_MODEL,
+            "LiteLLM": CONF_LITELLM_MODEL,
         }
         model_key = model_key_map.get(provider)
         return self._opt(model_key, DEFAULT_MODELS.get(provider, "unknown")) if model_key else "unknown"
@@ -487,6 +488,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             "OpenRouter": self._openrouter,
             "OpenAI Azure": self._openai_azure,
             "Generic OpenAI": self._generic_openai,
+            "LiteLLM": self._litellm,
         }
         handler = dispatch.get(provider)
         if handler is None:
@@ -881,3 +883,38 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             provider_label="OpenRouter",
         )
         return self._extract_chat_content(response, "OpenRouter") if response else None
+
+    async def _litellm(self, prompt: str) -> str | None:
+        import litellm
+
+        model = self._current_model("LiteLLM")
+        _, out_budget = self._budgets()
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": self._trim_prompt(prompt)}],
+            "max_tokens": out_budget,
+            "temperature": float(self._opt(CONF_LITELLM_TEMPERATURE, DEFAULT_TEMPERATURE)),
+        }
+        api_key = self._opt(CONF_LITELLM_API_KEY)
+        if api_key:
+            kwargs["api_key"] = api_key
+        api_base = self._opt(CONF_LITELLM_API_BASE)
+        if api_base:
+            kwargs["api_base"] = api_base
+
+        timeout_seconds = int(self._opt(CONF_REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT))
+        kwargs["timeout"] = max(10, timeout_seconds)
+
+        response = await litellm.acompletion(**kwargs)
+        self._last_response_metadata = {
+            "finish_reason": response.choices[0].finish_reason,
+            "usage": {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            },
+        }
+        content = response.choices[0].message.content
+        if content is None:
+            raise ValueError("LiteLLM response missing content")
+        return content

--- a/custom_components/ai_automation_suggester/manifest.json
+++ b/custom_components/ai_automation_suggester/manifest.json
@@ -10,6 +10,7 @@
   "requirements": [
     "anthropic>=0.8.0",
     "aiohttp>=3.8.0",
+    "litellm>=1.67.0",
     "pyyaml>=6.0",
     "voluptuous>=0.13.1"
   ],

--- a/custom_components/ai_automation_suggester/strings.json
+++ b/custom_components/ai_automation_suggester/strings.json
@@ -141,6 +141,17 @@
           "max_input_tokens": "Max Input Tokens",
           "max_output_tokens": "Max Output Tokens"
         }
+      },
+      "litellm": {
+        "title": "Configure LiteLLM",
+        "data": {
+          "litellm_model": "LiteLLM Model (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6, groq/llama-3.3-70b-versatile)",
+          "litellm_api_key": "API Key (optional if set via environment variable)",
+          "litellm_api_base": "API Base URL (optional, for LiteLLM proxy)",
+          "litellm_temperature": "Temperature",
+          "max_input_tokens": "Max Input Tokens",
+          "max_output_tokens": "Max Output Tokens"
+        }
       }
     },
     "error": {
@@ -207,6 +218,10 @@
           "generic_openai_temperature": "Temperature (Generic OpenAI)",
           "generic_openai_validation_endpoint": "Validation URL (Generic OpenAI, should end with 'models')",
           "generic_openai_enable_validation": "Enable Validation (Generic OpenAI)",
+          "litellm_api_key": "LiteLLM API Key",
+          "litellm_model": "LiteLLM Model",
+          "litellm_api_base": "LiteLLM API Base URL",
+          "litellm_temperature": "Temperature (LiteLLM)",
           "max_input_tokens": "Max Input Tokens",
           "max_output_tokens": "Max Output Tokens",
           "custom_system_prompt": "Persistent Custom System Prompt",

--- a/custom_components/ai_automation_suggester/translations/en.json
+++ b/custom_components/ai_automation_suggester/translations/en.json
@@ -141,6 +141,17 @@
           "max_input_tokens": "Max Input Tokens",
           "max_output_tokens": "Max Output Tokens"
         }
+      },
+      "litellm": {
+        "title": "Configure LiteLLM",
+        "data": {
+          "litellm_model": "LiteLLM Model (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6, groq/llama-3.3-70b-versatile)",
+          "litellm_api_key": "API Key (optional if set via environment variable)",
+          "litellm_api_base": "API Base URL (optional, for LiteLLM proxy)",
+          "litellm_temperature": "Temperature",
+          "max_input_tokens": "Max Input Tokens",
+          "max_output_tokens": "Max Output Tokens"
+        }
       }
     },
     "error": {
@@ -207,6 +218,10 @@
           "generic_openai_temperature": "Temperature (Generic OpenAI)",
           "generic_openai_validation_endpoint": "Validation URL (Generic OpenAI, should end with 'models')",
           "generic_openai_enable_validation": "Enable Validation (Generic OpenAI)",
+          "litellm_api_key": "LiteLLM API Key",
+          "litellm_model": "LiteLLM Model",
+          "litellm_api_base": "LiteLLM API Base URL",
+          "litellm_temperature": "Temperature (LiteLLM)",
           "max_input_tokens": "Max Input Tokens",
           "max_output_tokens": "Max Output Tokens",
           "custom_system_prompt": "Persistent Custom System Prompt",


### PR DESCRIPTION
Adds [LiteLLM](https://github.com/BerriAI/litellm) as a provider option, giving users access to 100+ LLM providers (OpenAI, Anthropic, Google, Groq, Together AI, AWS Bedrock, Azure, Ollama, etc.) through a single unified interface.

## Summary

- New `_litellm()` method in `coordinator.py` using `litellm.acompletion()` (async SDK, not proxy)
- "LiteLLM" added to provider dropdown in `config_flow.py` with setup step + options flow
- Constants (`CONF_LITELLM_MODEL`, `CONF_LITELLM_API_KEY`, `CONF_LITELLM_API_BASE`, `CONF_LITELLM_TEMPERATURE`) added to `const.py`
- `litellm>=1.67.0` added to `manifest.json` requirements
- UI labels added to `strings.json` and `translations/en.json`
- Users specify any LiteLLM model string (e.g. `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, `groq/llama-3.3-70b-versatile`); API keys can be set in the UI or via environment variables

## Testing

- [x] `pytest` -- 19 passed, 0 failures, no regressions
- [ ] HACS validation
- [ ] hassfest validation

## Home Assistant Notes

- Minimum HA version affected: N/A (no HA API changes, new provider only)
- Providers tested: Anthropic (via LiteLLM SDK)
- Model IDs tested: `anthropic/claude-sonnet-4-6`
